### PR TITLE
matrix: Use degrees in the graphene_matrix_t rotation API

### DIFF
--- a/src/graphene-matrix.c
+++ b/src/graphene-matrix.c
@@ -143,9 +143,13 @@ graphene_matrix_init_perspective (graphene_matrix_t *m,
                                   float              z_near,
                                   float              z_far)
 {
+  float fovy_rad;
+
   g_return_val_if_fail (m != NULL, NULL);
 
-  graphene_simd4x4f_init_perspective (&m->value, fovy, aspect, z_near, z_far);
+  fovy_rad = fovy * GRAPHENE_PI / 180.f;
+
+  graphene_simd4x4f_init_perspective (&m->value, fovy_rad, aspect, z_near, z_far);
 
   return m;
 }
@@ -238,10 +242,14 @@ graphene_matrix_init_rotate (graphene_matrix_t     *m,
                              float                  angle,
                              const graphene_vec3_t *axis)
 {
+  float rad;
+
   g_return_val_if_fail (m != NULL, NULL);
   g_return_val_if_fail (axis != NULL, m);
 
-  graphene_simd4x4f_rotation (&m->value, angle, axis->value);
+  rad = angle * GRAPHENE_PI / 180.f;
+
+  graphene_simd4x4f_rotation (&m->value, rad, axis->value);
 
   return m;
 }
@@ -722,8 +730,11 @@ graphene_matrix_rotate (graphene_matrix_t     *m,
                         const graphene_vec3_t *axis)
 {
   graphene_simd4x4f_t rot_m;
+  float rad;
 
-  graphene_simd4x4f_rotation (&rot_m, angle, axis->value);
+  rad = angle * GRAPHENE_PI / 180.f;
+
+  graphene_simd4x4f_rotation (&rot_m, rad, axis->value);
   graphene_simd4x4f_matrix_mul (&m->value, &rot_m, &m->value);
 }
 

--- a/src/tests/matrix.c
+++ b/src/tests/matrix.c
@@ -2,12 +2,6 @@
 #include <graphene.h>
 #include <math.h>
 
-static float
-deg_to_rad (float degree)
-{
-  return degree * GRAPHENE_PI / 180.0f;
-}
-
 #define g_assert_fuzzy_float_eq(n1,n2,d) \
   do { long double __n1 = (n1), __n2 = (n2), __d = (d); \
      if (fabsl (__n1 - __n2) < __d) ; else \
@@ -69,8 +63,8 @@ matrix_rotation (void)
   graphene_matrix_init_identity (&m);
   g_assert_true (graphene_matrix_is_identity (&m));
 
-  graphene_matrix_rotate (&m, deg_to_rad (180.0f), graphene_vec3_x_axis ());
-  graphene_matrix_init_rotate (&m2, deg_to_rad (180.0f), graphene_vec3_x_axis ());
+  graphene_matrix_rotate (&m, 180.0f, graphene_vec3_x_axis ());
+  graphene_matrix_init_rotate (&m2, 180.0f, graphene_vec3_x_axis ());
 
   if (g_test_verbose ())
     graphene_matrix_print (&m);


### PR DESCRIPTION
We can keep using radians in the underlying SIMD implementation, but the
public-facing convenience API should use the more convenient unit
instead.

Fixes issue #4.
