### PR TITLE
Some matrix tests

### DIFF
--- a/src/tests/matrix.c
+++ b/src/tests/matrix.c
@@ -63,8 +63,8 @@ matrix_rotation (void)
   graphene_matrix_init_identity (&m);
   g_assert_true (graphene_matrix_is_identity (&m));
 
-  graphene_matrix_rotate (&m, 180.0f, graphene_vec3_x_axis ());
-  graphene_matrix_init_rotate (&m2, 180.0f, graphene_vec3_x_axis ());
+  graphene_matrix_rotate (&m, 10.0f, graphene_vec3_x_axis ());
+  graphene_matrix_init_rotate (&m2, 10.0f, graphene_vec3_x_axis ());
 
   if (g_test_verbose ())
     graphene_matrix_print (&m);


### PR DESCRIPTION
- Add a neutral element test, where the identity matrix is transformed and should stay the same.
- Show that matrix multiplication fails for rotations not dividable by 90°
