### PR TITLE
build: Add -mfloat-abi=softfp on Android

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -237,6 +237,18 @@ AS_CASE([$host_os],
 # Check for ARM NEON instructions
 AS_IF([test "x$NEON_CFLAGS" = "x"], [NEON_CFLAGS="-mfpu=neon"])
 
+# the Android toolchain needs some further handholding
+AC_MSG_CHECKING([if we are on Android])
+AS_CASE([$host_os],
+
+        [*android*],
+        [
+          AC_MSG_RESULT([yes])
+          NEON_CFLAGS="$NEON_CFLAGS -mfloat-abi=softfp"
+        ],
+        
+        [AC_MSG_RESULT([no])])
+
 have_arm_neon=no
 AC_MSG_CHECKING([whether to use ARM NEON assembler])
 saved_CFLAGS="$CFLAGS"


### PR DESCRIPTION
It seems that Android requires `-mfloat-abi=softfp -mfpu=neon` in the
compilation flags in order to use the NEON instructions, even if the
configure time check passes with `-mfpu=neon` alone.

[ebassi/graphene#12]
