### PR TITLE
graphene-simd4f.h: Fix MSVC Defines for Intrinistics

### DIFF
--- a/src/graphene-simd4f.h
+++ b/src/graphene-simd4f.h
@@ -645,7 +645,7 @@ static inline bool
 _simd4f_cmp_eq (const graphene_simd4f_t a,
                         const graphene_simd4f_t b)
 {
-  __m128i __res = _mm_castps_si128 (_mm_cmpeq_ps (a, b));
+  __m128i __res = _mm_castps_si128 (_mm_cmpneq_ps (a, b));
   return (_mm_movemask_epi8 (__res) == 0);
 }
 
@@ -666,7 +666,7 @@ _simd4f_cmp_lt (const graphene_simd4f_t a,
                 const graphene_simd4f_t b)
 {
   __m128i __res = _mm_castps_si128 (_mm_cmplt_ps (a, b));
-  return (_mm_movemask_epi8 (__res) != 0);
+  return (_mm_movemask_epi8 (__res) == 0xffff);
 }
 
 #define graphene_simd4f_cmp_le(a,b) _simd4f_cmp_le(a,b)
@@ -676,7 +676,7 @@ _simd4f_cmp_le (const graphene_simd4f_t a,
                 const graphene_simd4f_t b)
 {
   __m128i __res = _mm_castps_si128 (_mm_cmple_ps (a, b));
-  return (_mm_movemask_epi8 (__res) != 0);
+  return (_mm_movemask_epi8 (__res) == 0xffff);
 }
 
 #define graphene_simd4f_cmp_ge(a,b) _simd4f_cmp_ge(a,b)
@@ -686,17 +686,17 @@ _simd4f_cmp_ge (const graphene_simd4f_t a,
                 const graphene_simd4f_t b)
 {
   __m128i __res = _mm_castps_si128 (_mm_cmpge_ps (a, b));
-  return (_mm_movemask_epi8 (__res) != 0);
+  return (_mm_movemask_epi8 (__res) == 0xffff);
 }
 
 #define graphene_simd4f_cmp_gt(a,b) _simd4f_cmp_gt(a,b)
 
 static inline bool
-_simd4f_cmp_lt (const graphene_simd4f_t a,
+_simd4f_cmp_gt (const graphene_simd4f_t a,
                 const graphene_simd4f_t b)
 {
   __m128i __res = _mm_castps_si128 (_mm_cmpgt_ps (a, b));
-  return (_mm_movemask_epi8 (__res) != 0);
+  return (_mm_movemask_epi8 (__res) == 0xffff);
 }
 
 #define graphene_simd4f_neg(s) _simd4f_neg(s)


### PR DESCRIPTION
Hi,

There were some issues with commit 9b0b22c (simd4f: Add more comparison operators) in regards to the MSVC intrinistics calls, as the "new" MSVC initrinics calls were not correct (i.e. they should be in-sync with
the GCC ones, with syntax differences accounted for), and a function name was off, which broke the build and the tests.  Fix that.

p.s. The code in its current state is only buildable with Visual Studio 2013 for Visual Studio, so just wondering whether Graphene will become strictly C99 (judging by the use of fmaxf() and INFINITY)?  Just wondering, are there any recent plans to hard-require Graphene for GTK+ very, very soon (i.e. in 3.15.x)?

With blessings, thank you!
