### PR TITLE
Fix graphene_simd4x4f_init_look_at

### DIFF
--- a/src/graphene-simd4x4f.h
+++ b/src/graphene-simd4x4f.h
@@ -532,10 +532,6 @@ graphene_simd4x4f_init_look_at (graphene_simd4x4f_t *m,
   m->x = x_axis;
   m->y = y_axis;
   m->z = z_axis;
-  m->w = graphene_simd4f_init (0.0f, 0.0f, 0.0f, 1.0f);
-
-  graphene_simd4x4f_transpose_in_place (m);
-
   m->w = graphene_simd4f_init (x, y, z, 1.0f);
 }
 


### PR DESCRIPTION
I don't understand why this should ever be transposed, and
with this fix gthree_object_look_at() in Gthree finally works.

That said, this breaks the tests, so either Gthree is wrong (but i
don't think so) or the tests need fixing.
