### PR TITLE
Fix build on Windows

### DIFF
--- a/src/graphene-box.c
+++ b/src/graphene-box.c
@@ -46,6 +46,11 @@
 #include <errno.h>
 #endif
 
+#if HAVE_INIT_ONCE
+#define _WIN32_WINNT 0x0600
+#include <windows.h>
+#endif
+
 /**
  * graphene_box_alloc: (constructor)
  *

--- a/src/graphene-box.c
+++ b/src/graphene-box.c
@@ -38,6 +38,7 @@
 #include "graphene-sphere.h"
 
 #include <math.h>
+#include <stdio.h>
 
 #if HAVE_PTHREAD
 #include <pthread.h>

--- a/src/graphene-private.h
+++ b/src/graphene-private.h
@@ -25,7 +25,6 @@
 #define __GRAPHENE_PRIVATE_H__
 
 #include "config.h"
-#include <stdio.h>
 #include <stdlib.h>
 
 #define GRAPHENE_FLOAT_EPSILON  (1e-15)
@@ -81,6 +80,6 @@
 #define GRAPHENE_DEG_TO_RAD(x)          ((x) * (GRAPHENE_PI / 180.f))
 #define GRAPHENE_RAD_TO_DEG(x)          ((x) * (180.f / GRAPHENE_PI))
 
-#define graphene_lerp(a,b,ff)           (((1.f - (ff)) * (a)) + ((ff) * (b)))
+#define graphene_lerp(a,b,factor)       (((1.f - (factor)) * (a)) + ((factor) * (b)))
 
 #endif /* __GRAPHENE_PRIVATE_H__ */

--- a/src/graphene-private.h
+++ b/src/graphene-private.h
@@ -25,6 +25,7 @@
 #define __GRAPHENE_PRIVATE_H__
 
 #include "config.h"
+#include <stdio.h>
 #include <stdlib.h>
 
 #define GRAPHENE_FLOAT_EPSILON  (1e-15)
@@ -80,6 +81,6 @@
 #define GRAPHENE_DEG_TO_RAD(x)          ((x) * (GRAPHENE_PI / 180.f))
 #define GRAPHENE_RAD_TO_DEG(x)          ((x) * (180.f / GRAPHENE_PI))
 
-#define graphene_lerp(a,b,f)            (((1.f - (f)) * (a)) + ((f) * (b)))
+#define graphene_lerp(a,b,ff)           (((1.f - (ff)) * (a)) + ((ff) * (b)))
 
 #endif /* __GRAPHENE_PRIVATE_H__ */

--- a/src/graphene-vectors.c
+++ b/src/graphene-vectors.c
@@ -33,7 +33,7 @@
 #endif
 
 #if HAVE_INIT_ONCE
-#define _WIN32_WINNT 0x600
+#define _WIN32_WINNT 0x0600
 #include <windows.h>
 #endif
 
@@ -1889,7 +1889,7 @@ BOOL CALLBACK InitVec4Func (PINIT_ONCE InitOnce,
 }
 
 static inline void
-init_static_vec2 (void)
+init_static_vec4 (void)
 {
   BOOL bStatus = InitOnceExecuteOnce (&static_vec4_once,
                                       InitVec4Func,

--- a/src/graphene-vectors.c
+++ b/src/graphene-vectors.c
@@ -25,6 +25,8 @@
 #include "graphene-vectors-private.h"
 #include "graphene-alloc-private.h"
 
+#include <stdio.h>
+
 #if HAVE_PTHREAD
 #include <pthread.h>
 #include <errno.h>


### PR DESCRIPTION
Hi,

The recent updates to Graphene broke the build on Windows, which can be fixed with some rather simple updates.  I have made the necessary updates to the sources in my fork so that these issues could be remedied.

I will also try to come up with Visual Studio projects/NMake Makefiles to build the sources as soon as possible-sorry I did not have the time to look into Graphene lately due to work on other items.

p.s. Is it correct to assume that there is no intention to support Windows XP for this project, just to double-check (I couldn't check XP compatibility, as I don't normally run it, and I am all for dropping XP support in the GTK+ stack :) ), at least from a thread-safety perspective?

With blessings, thank you!