### PR TITLE
alloc: Include errno.h

### DIFF
--- a/src/graphene-alloc.c
+++ b/src/graphene-alloc.c
@@ -41,6 +41,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <errno.h>
 
 /*< private >
  * graphene_aligned_alloc:


### PR DESCRIPTION
This fixes build errors on Android:

graphene-alloc.c: In function 'graphene_aligned_alloc':
graphene-alloc.c:103:3: error: 'errno' undeclared (first use in this function)
   errno = 0;