### PR TITLE
Install graphene-config.h in libdir

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -79,6 +79,8 @@ endif
 # config header
 DISTCLEANFILES += graphene-config-stamp graphene-config.h
 BUILT_SOURCES += graphene-config-stamp
+configexecincludedir = $(libdir)/graphene-1.0/include
+nodist_configexecinclude_HEADERS = graphene-config.h
 graphene-config-stamp: ../config.status
 	$(AM_V_GEN) cd $(top_builddir) && \
 	  $(SHELL) ./config.status src/graphene-config.h
@@ -119,7 +121,6 @@ lib_LTLIBRARIES += libgraphene-1.0.la
 grapheneincludedir = $(includedir)/graphene-1.0
 grapheneinclude_HEADERS = $(source_h) graphene.h
 nodist_grapheneinclude_HEADERS = \
-	$(top_builddir)/src/graphene-config.h \
 	$(top_builddir)/src/graphene-version.h \
 	$(NULL)
 

--- a/src/graphene.pc.in
+++ b/src/graphene.pc.in
@@ -11,5 +11,5 @@ Description: Math classes for graphic libraries
 Version: @VERSION@
 Libs: -L${libdir} -lgraphene-1.0
 Libs.private: @PTHREAD_LIBS@
-Cflags: -I${includedir}/graphene-1.0
+Cflags: -I${includedir}/graphene-1.0 -I${libdir}/graphene-1.0/include
 Requires.private: @GRAPHENE_REQS@


### PR DESCRIPTION
This file is architecture dependent. To support multilib we need
to make sure multiple copies can coexist.