### PR TITLE
Reverse multiplication order for in-place operations

### DIFF
--- a/src/graphene-matrix.c
+++ b/src/graphene-matrix.c
@@ -1328,7 +1328,7 @@ graphene_matrix_translate (graphene_matrix_t        *m,
   graphene_simd4x4f_t trans_m;
 
   graphene_simd4x4f_translation (&trans_m, pos->x, pos->y, pos->z);
-  graphene_simd4x4f_matrix_mul (&m->value, &trans_m, &m->value);
+  graphene_simd4x4f_matrix_mul (&trans_m, &m->value, &m->value);
 }
 
 /**
@@ -1348,7 +1348,7 @@ graphene_matrix_rotate_quaternion (graphene_matrix_t           *m,
   graphene_matrix_t rot;
 
   graphene_quaternion_to_matrix (q, &rot);
-  graphene_matrix_multiply (m, &rot, m);
+  graphene_matrix_multiply (&rot, m, m);
 }
 
 /**
@@ -1379,7 +1379,7 @@ graphene_matrix_rotate_internal (graphene_simd4x4f_t     *m,
   graphene_simd4x4f_t rot_m;
 
   graphene_simd4x4f_rotation (&rot_m, rad, axis);
-  graphene_simd4x4f_matrix_mul (m, &rot_m, m);
+  graphene_simd4x4f_matrix_mul (&rot_m, m, m);
 }
 
 /**
@@ -1476,7 +1476,7 @@ graphene_matrix_scale (graphene_matrix_t *m,
   graphene_simd4x4f_t scale_m;
 
   graphene_simd4x4f_scale (&scale_m, factor_x, factor_y, factor_z);
-  graphene_simd4x4f_matrix_mul (&m->value, &scale_m, &m->value);
+  graphene_simd4x4f_matrix_mul (&scale_m, &m->value, &m->value);
 }
 
 /**

--- a/src/graphene-simd4x4f.h
+++ b/src/graphene-simd4x4f.h
@@ -431,13 +431,16 @@ graphene_simd4x4f_matrix_mul (const graphene_simd4x4f_t *a,
   const graphene_simd4f_t row3 = a->z;
   const graphene_simd4f_t row4 = a->w;
 
+  graphene_simd4x4f_t r;
+
   /* the order is correct if we want to multiply A with B; remember
    * that matrix multiplication is non-commutative.
    */
-  graphene_simd4x4f_vec4_mul (b, &row1, &res->x);
-  graphene_simd4x4f_vec4_mul (b, &row2, &res->y);
-  graphene_simd4x4f_vec4_mul (b, &row3, &res->z);
-  graphene_simd4x4f_vec4_mul (b, &row4, &res->w);
+  graphene_simd4x4f_vec4_mul (b, &row1, &r.x);
+  graphene_simd4x4f_vec4_mul (b, &row2, &r.y);
+  graphene_simd4x4f_vec4_mul (b, &row3, &r.z);
+  graphene_simd4x4f_vec4_mul (b, &row4, &r.w);
+  res->x = r.x; res->y = r.y; res->z = r.z; res->w = r.w;
 #endif
 }
 

--- a/src/graphene-simd4x4f.h
+++ b/src/graphene-simd4x4f.h
@@ -440,7 +440,10 @@ graphene_simd4x4f_matrix_mul (const graphene_simd4x4f_t *a,
   graphene_simd4x4f_vec4_mul (b, &row2, &r.y);
   graphene_simd4x4f_vec4_mul (b, &row3, &r.z);
   graphene_simd4x4f_vec4_mul (b, &row4, &r.w);
-  res->x = r.x; res->y = r.y; res->z = r.z; res->w = r.w;
+  res->x = r.x;
+  res->y = r.y;
+  res->z = r.z;
+  res->w = r.w;
 #endif
 }
 

--- a/src/tests/matrix.c
+++ b/src/tests/matrix.c
@@ -355,8 +355,8 @@ GRAPHENE_TEST_UNIT_BEGIN (matrix_2d_transforms)
   graphene_point3d_t tmp;
 
   graphene_matrix_init_identity (&m1);
-  graphene_matrix_scale (&m1, 2.0, 2.0, 1.0);
   graphene_matrix_translate (&m1, graphene_point3d_init (&tmp, 0.5, 0.5, 0.0));
+  graphene_matrix_scale (&m1, 2.0, 2.0, 1.0);
   if (g_test_verbose ())
     {
       g_test_message ("m1 -> translate(0.5, 0.5, 0.0) -> scale(2.0, 2.0)");
@@ -386,9 +386,9 @@ GRAPHENE_TEST_UNIT_BEGIN (matrix_2d_transforms)
   graphene_assert_fuzzy_equals (y_0, 0.5, 0.0001);
 
   graphene_matrix_init_identity (&m1);
-  graphene_matrix_translate (&m1, graphene_point3d_init (&tmp, 50, 50, 0));
-  graphene_matrix_rotate_z (&m1, 45.0);
   graphene_matrix_translate (&m1, graphene_point3d_init (&tmp, -50, -50, 0));
+  graphene_matrix_rotate_z (&m1, 45.0);
+  graphene_matrix_translate (&m1, graphene_point3d_init (&tmp, 50, 50, 0));
   if (g_test_verbose ())
     {
       g_test_message ("m1 -> translate(50,50) -> rotate(45deg) -> translate(-50, -50)");
@@ -398,8 +398,8 @@ GRAPHENE_TEST_UNIT_BEGIN (matrix_2d_transforms)
   g_assert_true (graphene_matrix_is_2d (&m1));
 
   graphene_matrix_init_identity (&m1);
-  graphene_matrix_perspective (&m1, 500, &m1);
   graphene_matrix_rotate_y (&m1, 50.0);
+  graphene_matrix_perspective (&m1, 500, &m1);
   if (g_test_verbose ())
     {
       g_test_message ("m1 -> perspective(500) -> rotateY(50deg)");


### PR DESCRIPTION
This patch reverses the order of multiplication for operations that modify the matrix in place, e.g. rotate, translate, scale.  It _does not_ change the order of the matrix multiply functions, but does add a temp variable and copy (should be negligible, on the order of microseconds or less -- about 15ns on my system).
