### PR TITLE
docs: improve doc of graphene_sphere_translate()

### DIFF
--- a/src/graphene-sphere.c
+++ b/src/graphene-sphere.c
@@ -333,8 +333,8 @@ graphene_sphere_get_bounding_box (const graphene_sphere_t *s,
  * @point: the coordinates of the translation
  * @res: (out caller-allocates): return location for the translated sphere
  *
- * Translates the center of the given #graphene_sphere_t using the
- * coordinates inside @point.
+ * Translates the center of the given #graphene_sphere_t using the @point
+ * coordinates as the delta of the translation.
  *
  * Since: 1.2
  */


### PR DESCRIPTION
I know what is a translation, but it was not clear to me whether @point
referred to the new center coordinates, or the delta. It turns out that
it's the delta, as expected for a translation, but it's better to
explain it in the docs.