### PR TITLE
graphene-simd4x4f.h: Fix x86 Builds on MSVC 2013 and Later

### DIFF
--- a/src/graphene-simd4x4f.h
+++ b/src/graphene-simd4x4f.h
@@ -68,8 +68,7 @@ GRAPHENE_BEGIN_DECLS
  *
  * Since: 1.0
  */
-GRAPHENE_VECTORCALL
-static inline graphene_simd4x4f_t
+static inline graphene_simd4x4f_t GRAPHENE_VECTORCALL
 graphene_simd4x4f_init (graphene_simd4f_t x,
                         graphene_simd4f_t y,
                         graphene_simd4f_t z,


### PR DESCRIPTION
Hi,

(Sorry, I forgot to post about this, which was an issue for a while...)

The current placement of GRAPHENE_VECTORCALL, which is expanded to __vectorcall on Visual Studio 2013 and later (for 32-bit builds) is actually breaking the build there.  That needs to be done after the return type.

With blessings, thank you!