### PR TITLE
Fix building graphene as a meson submodule

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,11 @@ graphene_minor_version = version_array[1]
 graphene_micro_version = version_array[2]
 
 graphene_api_version = '@0@.0'.format(graphene_major_version)
+soversion = 0
+# maintaining compatibility with the previous libtool versioning
+# current = minor * 100 + micro
+libversion = '@0@.@1@.0'.format(soversion, graphene_minor_version.to_int() * 100 +
+  graphene_major_version.to_int())
 
 graphene_interface_age = graphene_micro_version
 soname_age = 0

--- a/meson.build
+++ b/meson.build
@@ -118,6 +118,7 @@ if get_option('enable-debug') == 'no'
   ]
 endif
 
+extra_args= []
 # Detect and set symbol visibility
 if get_option('default_library') != 'static'
   if host_system == 'windows'
@@ -126,11 +127,11 @@ if get_option('default_library') != 'static'
       conf.set('_GRAPHENE_PUBLIC', '__declspec(dllexport) extern')
     else
       conf.set('_GRAPHENE_PUBLIC', '__attribute__((visibility("default"))) __declspec(dllexport) extern')
-      add_global_arguments('-fvisibility=hidden', language: 'c')
+      extra_args += ['-fvisibility=hidden']
     endif
   else
     conf.set('_GRAPHENE_PUBLIC', '__attribute__((visibility("default")))')
-    add_global_arguments('-fvisibility=hidden', language: 'c')
+    extra_args += ['-fvisibility=hidden']
   endif
 endif
 
@@ -198,9 +199,9 @@ int main () {
   if cc.compiles(sse_prog, name: 'SSE intrinsics')
     graphene_conf.set('GRAPHENE_HAS_SSE', 1)
     conf.set('SSE2_CFLAGS', '-mfpmath=sse -msse -msse2')
-    add_global_arguments('-mfpmath=sse', language: 'c')
-    add_global_arguments('-msse', language: 'c')
-    add_global_arguments('-msse2', language: 'c')
+    extra_args += ['-mfpmath=sse']
+    extra_args += ['-msse']
+    extra_args += ['-msse2']
     graphene_simd += [ 'sse2' ]
   endif
 endif
@@ -256,10 +257,10 @@ int main () {
 }'''
   if cc.compiles(neon_prog, name: 'ARM NEON intrinsics')
     graphene_conf.set('GRAPHENE_HAS_ARM_NEON', 1)
-    add_global_arguments('-mfpu=neon', language: 'c')
+    extra_args += ['-mfpu=neon']
 
     if host_system == 'android'
-      add_global_arguments('-mfloat-abi=softfp', language: 'c')
+      extra_args += ['-mfloat-abi=softfp']
       conf.set('NEON_CFLAGS', '-mfpu=neon -mfloat-abi=softfp')
     else
       conf.set('NEON_CFLAGS', '-mfpu=neon')

--- a/src/meson.build
+++ b/src/meson.build
@@ -93,8 +93,8 @@ endif
 
 libgraphene = shared_library('graphene-@0@'.format(graphene_api_version),
   sources: sources + simd_sources + private_headers,
-  version: graphene_version,
-  soversion: graphene_lib_version0,
+  version: libversion,
+  soversion: soversion,
   install: true,
   dependencies: [ mathlib, threadlib ] + platform_deps,
   c_args: extra_args + common_flags + debug_flags + [

--- a/src/meson.build
+++ b/src/meson.build
@@ -105,7 +105,7 @@ libgraphene = shared_library('graphene-@0@'.format(graphene_api_version),
   link_args: [ '-Wl,-Bsymbolic-functions' ])
 
 # Internal dependency, for tests and benchmarks
-graphene_inc = include_directories([ meson.source_root() + '/src', meson.build_root() + '/src' ])
+graphene_inc = include_directories([ meson.current_source_dir(), meson.current_build_dir() ])
 graphene_dep = declare_dependency(link_with: libgraphene,
                                   include_directories: [ graphene_inc ],
                                   dependencies: [ mathlib, threadlib ] + platform_deps)
@@ -121,13 +121,13 @@ endforeach
 
 if build_gir
   gir_extra_args = [
-    '--identifier-filter-cmd=' + meson.source_root() + '/src/identfilter.py',
+    '--identifier-filter-cmd=' + meson.current_source_dir() + '/identfilter.py',
     '--c-include=graphene-gobject.h',
     '--accept-unprefixed',
     '-DGRAPHENE_COMPILATION',
     '--cflags-begin',
-    '-I' + meson.source_root() + '/src',
-    '-I' + meson.build_root() + '/src',
+    '-I' + meson.current_source_dir(),
+    '-I' + meson.current_build_dir(),
     '--cflags-end'
   ]
   gnome.generate_gir(libgraphene,

--- a/src/meson.build
+++ b/src/meson.build
@@ -94,10 +94,10 @@ endif
 libgraphene = shared_library('graphene-@0@'.format(graphene_api_version),
   sources: sources + simd_sources + private_headers,
   version: graphene_version,
-  soversion: graphene_lib_version,
+  soversion: graphene_lib_version0,
   install: true,
   dependencies: [ mathlib, threadlib ] + platform_deps,
-  c_args: common_flags + debug_flags + [
+  c_args: extra_args + common_flags + debug_flags + [
             '-DGRAPHENE_COMPILATION',
             '-DG_LOG_DOMAIN="Graphene"',
             '-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_30',


### PR DESCRIPTION
Fixes building graphene as a meson submodule

Proposed changes:

   - meson: Fix library version and soversion
   - meson: Do not use add_global_arguments but instead pass the args ourself