### PR TITLE
Fixing build errors on ARM NEON.

### DIFF
--- a/src/graphene-matrix.c
+++ b/src/graphene-matrix.c
@@ -746,7 +746,25 @@ graphene_matrix_get_value (const graphene_matrix_t *m,
       return 0.f;
     }
 
-  return graphene_simd4f_get (r, col);
+  switch (col)
+    {
+    case 0:
+      return graphene_simd4f_get (r, 0);
+
+    case 1:
+      return graphene_simd4f_get (r, 1);
+
+    case 2:
+      return graphene_simd4f_get (r, 2);
+
+    case 3:
+      return graphene_simd4f_get (r, 3);
+
+    default:
+      return 0.f;
+    }
+
+  return 0.f;
 }
 
 /**

--- a/src/graphene-simd4f.c
+++ b/src/graphene-simd4f.c
@@ -216,7 +216,23 @@ float
 (graphene_simd4f_get) (const graphene_simd4f_t s,
                        unsigned int            i)
 {
-  return graphene_simd4f_get (s, i);
+  switch (i)
+    {
+    case 0:
+      return graphene_simd4f_get (s, 0);
+
+    case 1:
+      return graphene_simd4f_get (s, 1);
+
+    case 2:
+      return graphene_simd4f_get (s, 2);
+
+    case 3:
+      return graphene_simd4f_get (s, 3);
+
+    default:
+      return 0.f;
+  }
 }
 
 /**


### PR DESCRIPTION
Part 2 of splitting PR #64 into two separate PRs.

The underlying ARM fast type that graphene_simd4f_get calls into requires
its inputs to be compile time constants. Passing the "col" argument in was
causing the build to fail.