### PR TITLE
build: Allow proper build with Visual Studio out-of-the-box

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -58,35 +58,63 @@ conf.set('GRAPHENE_MICRO_VERSION', graphene_micro_version)
 conf.set('GRAPHENE_VERSION', graphene_version)
 
 # Compiler flags
-test_cflags = [
-  '-ffast-math',
-  '-fstrict-aliasing',
-  '-Wall',
-  '-Wpointer-arith',
-  '-Wmissing-declarations',
-  '-Wformat=2',
-  '-Wstrict-prototypes',
-  '-Wmissing-prototypes',
-  '-Wnested-externs',
-  '-Wold-style-definition',
-  '-Wdeclaration-after-statement',
-  '-Wunused',
-  '-Wuninitialized',
-  '-Wshadow',
-  '-Wmissing-noreturn',
-  '-Wmissing-format-attribute',
-  '-Wredundant-decls',
-  '-Wlogical-op',
-  '-Wcast-align',
-  '-Wno-unused-local-typedefs',
-  '-Werror=implicit',
-  '-Werror=init-self',
-  '-Werror=main',
-  '-Werror=missing-braces',
-  '-Werror=return-type',
-  '-Werror=array-bounds',
-  '-Werror=write-strings'
-]
+if cc.get_id() == 'msvc'
+  # Make MSVC more pedantic, this is a recommended pragma list
+  # from _Win32_Programming_ by Rector and Newcomer.  Taken from
+  # glib's msvc_recommended_pragmas.h--please see that file for
+  # the meaning of the warning codes used here
+  test_cflags = [
+    '-W3',
+    '-we4002',
+    '-we4003',
+    '-w14010',
+    '-we4013',
+    '-w14016',
+    '-we4020',
+    '-we4021',
+    '-we4027',
+    '-we4029',
+    '-we4033',
+    '-we4035',
+    '-we4045',
+    '-we4047',
+    '-we4049',
+    '-we4053',
+    '-we4071',
+    '-we4150',
+    '-we4819'
+  ]
+else
+  test_cflags = [
+    '-ffast-math',
+    '-fstrict-aliasing',
+    '-Wall',
+    '-Wpointer-arith',
+    '-Wmissing-declarations',
+    '-Wformat=2',
+    '-Wstrict-prototypes',
+    '-Wmissing-prototypes',
+    '-Wnested-externs',
+    '-Wold-style-definition',
+    '-Wdeclaration-after-statement',
+    '-Wunused',
+    '-Wuninitialized',
+    '-Wshadow',
+    '-Wmissing-noreturn',
+    '-Wmissing-format-attribute',
+    '-Wredundant-decls',
+    '-Wlogical-op',
+    '-Wcast-align',
+    '-Wno-unused-local-typedefs',
+    '-Werror=implicit',
+    '-Werror=init-self',
+    '-Werror=main',
+    '-Werror=missing-braces',
+    '-Werror=return-type',
+    '-Werror=array-bounds',
+    '-Werror=write-strings'
+  ]
+endif
 common_flags = []
 foreach cflag: test_cflags
   if cc.has_argument(cflag)
@@ -164,6 +192,11 @@ build_gobject = false
 if get_option('enable-gobject-types')
   gobject = dependency('gobject-2.0', version: '>= 2.30.0', required: false)
   build_gobject = gobject.found()
+  if build_gobject
+    if cc.get_id() == 'msvc'
+      extra_args += ['/FImsvc_recommended_pragmas.h']
+    endif
+  endif
   conf.set('GRAPHENE_REQS', 'gobject-2.0')
 endif
 
@@ -203,8 +236,12 @@ if get_option('enable-sse2')
 # if !defined(__amd64__) && !defined(__x86_64__)
 #   error "Need GCC >= 4.2 for SSE2 intrinsics on x86"
 # endif
+#elif defined (_MSC_VER) && (_MSC_VER < 1800)
+# if !defined (_M_X64) && !defined (_M_AMD64)
+#   error "Need MSVC 2013 or later for SSE2 intrinsics on x86"
+# endif
 #endif
-#if defined(__SSE__) || (_M_IX86_FP > 0) || (_M_X64 > 0)
+#if defined(__SSE__) || (_M_IX86_FP > 0) || (_M_X64 > 0) || (_MSC_VER >= 1800)
 # include <mmintrin.h>
 # include <xmmintrin.h>
 # include <emmintrin.h>
@@ -218,8 +255,10 @@ int main () {
 }'''
   if cc.compiles(sse_prog, name: 'SSE intrinsics')
     graphene_conf.set('GRAPHENE_HAS_SSE', 1)
-    conf.set('SSE2_CFLAGS', '-mfpmath=sse -msse -msse2')
-    extra_args += ['-mfpmath=sse', '-msse', '-msse2']
+    if cc.get_id() != 'msvc'
+      conf.set('SSE2_CFLAGS', '-mfpmath=sse -msse -msse2')
+      extra_args += ['-mfpmath=sse', '-msse', '-msse2']
+    endif
     graphene_simd += [ 'sse2' ]
   endif
 endif

--- a/src/graphene-config.h.meson
+++ b/src/graphene-config.h.meson
@@ -12,7 +12,7 @@ extern "C" {
 
 #ifndef GRAPHENE_SIMD_BENCHMARK
 
-# if defined(__SSE__) || (_M_IX86_FP > 0) || (_M_X64 > 0)
+# if defined(__SSE__) || (_M_IX86_FP > 0) || (_M_X64 > 0) || (_MSC_VER >= 1800)
 #mesondefine GRAPHENE_HAS_SSE
 # endif
 
@@ -53,6 +53,8 @@ extern "C" {
 #   endif
 #  elif defined(__SSE4_1__)
 #   define GRAPHENE_USE_SSE4_1
+#  elif defined(_MSC_VER)
+#   define GRAPHENE_USE_SSE4_1
 #  endif
 #  if defined(GRAPHENE_USE_SSE4_1)
 #   include <smmintrin.h>
@@ -91,6 +93,12 @@ typedef struct {
 
 #ifdef __cplusplus
 }
+#endif
+
+#ifdef _MSC_VER
+# if !defined (__cplusplus) && defined (_MSC_VER) && (_MSC_VER < 1900)
+#  define inline __inline
+# endif
 #endif
 
 #endif /* __GRAPHENE_CONFIG_H__ */

--- a/src/meson.build
+++ b/src/meson.build
@@ -91,6 +91,12 @@ if build_gobject
   platform_deps += [ gobject ]
 endif
 
+if cc.get_id() == 'msvc'
+  graphene_link_args = []
+else
+  graphene_link_args = [ '-Wl,-Bsymbolic-functions' ]
+endif
+
 libgraphene = shared_library('graphene-@0@'.format(graphene_api_version),
   sources: sources + simd_sources + private_headers,
   version: libversion,
@@ -102,7 +108,7 @@ libgraphene = shared_library('graphene-@0@'.format(graphene_api_version),
             '-DG_LOG_DOMAIN="Graphene"',
             '-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_30',
             '-DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_32' ],
-  link_args: [ '-Wl,-Bsymbolic-functions' ])
+  link_args: graphene_link_args)
 
 # Internal dependency, for tests and benchmarks
 graphene_inc = include_directories([ meson.current_source_dir(), meson.current_build_dir() ])


### PR DESCRIPTION
Hi,

This attempts to add proper support out-of-the box for building Graphene using Visual Studio, so that we can make use of it with Visual Studio builds of the upcoming GTK+-4.x (for GSK), as most of the code is ready for building and usage under Visual Studio 2008+ (!), but a build system that would support the MSVC toolchain is not yet in place.

As a result, updates are needed for the meson build files to support the toolchain properly, and a few minor changes are needed for the code so that things will work in the Visual Studio versions that we support for GTK+ (the code changes I will post later).  Note that on 32-bit builds, Visual Studio 2013 or later is required to enable SSE2 support due to x86/32-bit ABI limitations.

With blessings, thank you!
