### PR TITLE
build: install tests into libexecdir

### DIFF
--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -22,7 +22,7 @@ unit_tests = [
 foreach unit: unit_tests
   exe = executable(unit, unit + '.c',
                    install: true,
-                   install_dir: join_paths(graphene_datadir, 'installed-tests', 'graphene-1.0'),
+                   install_dir: join_paths(get_option('prefix'), get_option('libexecdir'), 'installed-tests', 'graphene-1.0'),
                    dependencies: graphene_dep,
                    include_directories: graphene_inc,
                    c_args: [


### PR DESCRIPTION
Tests are ELF files, so in case of multilib they will conflict. Using libexecdir will tell that this package is not multilib.

@ebassi though I'm not sure if we should use $libdir instead of $libexecdir.