### PR TITLE
Fix build of 1.5.1 on Visual Studio

### DIFF
--- a/src/config.h.meson
+++ b/src/config.h.meson
@@ -23,3 +23,8 @@
 
 /* Define for symbol visibility */
 #mesondefine _GRAPHENE_PUBLIC
+
+/* Define inline as __inline for older Visual Studio (<= 2013) builds */
+#if defined (_MSC_VER) && (_MSC_VER < 1900)
+#define inline __inline
+#endif

--- a/src/graphene-point.c
+++ b/src/graphene-point.c
@@ -295,7 +295,11 @@ graphene_point_to_vec2 (const graphene_point_t *p,
   v->value = graphene_simd4f_init (p->x, p->y, 0.f, 0.f);
 }
 
+#ifdef _MSC_VER
+static const graphene_point_t _graphene_point_zero = {0.f, 0.f};
+#else
 static const graphene_point_t _graphene_point_zero = GRAPHENE_POINT_INIT_ZERO;
+#endif
 
 /**
  * graphene_point_zero:

--- a/src/graphene-point3d.c
+++ b/src/graphene-point3d.c
@@ -443,7 +443,11 @@ graphene_point3d_normalize_viewport (const graphene_point3d_t *p,
   res->z = CLAMP (res->z * 2.f - 1.f, -1.f, 1.f);
 }
 
+#ifdef _MSC_VER
+static const graphene_point3d_t _graphene_point3d_zero = {0.f, 0.f, 0.f};
+#else
 static const graphene_point3d_t _graphene_point3d_zero = GRAPHENE_POINT3D_INIT_ZERO;
+#endif
 
 /**
  * graphene_point3d_zero:

--- a/src/graphene-rect.c
+++ b/src/graphene-rect.c
@@ -811,7 +811,11 @@ graphene_rect_interpolate (const graphene_rect_t *a,
   res->size.height = graphene_lerp (ra.size.height, rb.size.height, factor);
 }
 
+#ifdef _MSC_VER
+static const graphene_rect_t _graphene_rect_zero = { {0.f, 0.f}, {0.f, 0.f} };
+#else
 static const graphene_rect_t _graphene_rect_zero = GRAPHENE_RECT_INIT (0, 0, 0, 0);
+#endif
 
 /**
  * graphene_rect_zero:

--- a/src/graphene-size.c
+++ b/src/graphene-size.c
@@ -178,7 +178,11 @@ graphene_size_interpolate (const graphene_size_t *a,
   res->height = graphene_lerp (a->height, b->height, factor);
 }
 
+#ifdef _MSC_VER
+static const graphene_size_t _graphene_size_zero = {0.f, 0.f};
+#else
 static const graphene_size_t _graphene_size_zero = GRAPHENE_SIZE_INIT_ZERO;
+#endif
 
 /**
  * graphene_size_zero:


### PR DESCRIPTION
Hi,

We have started to use C99-style struct initializers, which is support by Visual Studio 2013/2015, with one exception, that is, using them in initializing static variables and global constants, which will cause C2099 to be raised (initializer not a constant).  This might also affect other compilers as well.

Also, we need to update config.h.meson to define inline as __inline for pre-2013 Visual Studio as well, in addition to graphene-config.h.meson.  I am not sure whether meson has a mechanism for detecting the 'inline' definition for the compiler, so this is what I have for now.

With bessings, thank you!