### PR TITLE
meson: Detect and use _aligned_malloc on MinGW

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -130,6 +130,7 @@ conf.set('HAVE_MEMORY_H', cc.has_header('memory.h'))
 
 # Functions
 conf.set('HAVE_ALIGNED_ALLOC', cc.has_function('aligned_alloc', prefix: '#include <stdlib.h>'))
+conf.set('HAVE__ALIGNED_MALLOC', cc.has_function('_aligned_malloc', prefix: '#include <stdlib.h>'))
 conf.set('HAVE_MEMALIGN', cc.has_function('memalign', prefix: '#include <stdlib.h>\n#include <malloc.h>'))
 conf.set('HAVE_POSIX_MEMALIGN', cc.has_function('posix_memalign', prefix: '#include <stdlib.h>'))
 conf.set('HAVE_SINCOSF', cc.has_function('sincosf', prefix: '#define _GNU_SOURCE\n#include <math.h>'))

--- a/src/bench/graphene-bench-utils.c
+++ b/src/bench/graphene-bench-utils.c
@@ -277,7 +277,7 @@ graphene_bench_print_results (const char *impl,
   switch (bench_output)
     {
     case BENCH_FORMAT_NONE:
-      g_print ("### '%s' (%ld iterations - using %s implementation) ###\n"
+      g_print ("### '%s' (%" G_GINT64_FORMAT " iterations - using %s implementation) ###\n"
                "         Total: %.6f %s (%d rounds)\n"
                "     Per round: %.6f %s (%d iterations per round)\n"
                " Per iteration: %.6f %s\n",

--- a/src/bench/matrix.c
+++ b/src/bench/matrix.c
@@ -4,15 +4,15 @@
 #define _XOPEN_SOURCE 600
 #endif
 
-#if defined(HAVE_MEMALIGN) || defined (_MSC_VER)
+#if defined(HAVE_MEMALIGN) || (defined(HAVE__ALIGNED_MALLOC) && defined (_MSC_VER))
 /* MSVC Builds: Required for _aligned_malloc() and _aligned_free() */
 #include <malloc.h>
 #endif
 
-#ifdef _MSC_VER
-/* On Visual Studio, _aligned_malloc() takes in parameters in inverted
- * order from aligned_alloc(), but things are more or less the same there
- * otherwise
+#ifdef HAVE__ALIGNED_MALLOC
+/* On Visual Studio and MinGW, _aligned_malloc() takes in parameters in
+ * inverted order from aligned_alloc(), but things are more or less the same
+ * there otherwise
  */
 #define aligned_alloc(alignment,size) _aligned_malloc (size, alignment)
 
@@ -53,11 +53,13 @@ alloc_align (gsize n,
 #if defined(HAVE_POSIX_MEMALIGN)
   if (posix_memalign (&res, alignment, real_size) != 0)
     g_assert_not_reached ();
-#elif defined(HAVE_ALIGNED_ALLOC) || defined (_MSC_VER)
+#elif defined(HAVE_ALIGNED_ALLOC) || defined (HAVE__ALIGNED_MALLOC)
   g_assert (real_size % alignment == 0);
   res = aligned_alloc (alignment, real_size);
 #elif defined(HAVE_MEMALIGN)
   res = memalign (alignment, real_size);
+#else
+#error "Need some type of aligned allocation function"
 #endif
 
   g_assert (res != NULL);

--- a/src/config.h.meson
+++ b/src/config.h.meson
@@ -3,6 +3,9 @@
 /* Define to 1 if you have the `aligned_alloc' function. */
 #mesondefine HAVE_ALIGNED_ALLOC
 
+/* Define to 1 if you have the `_aligned_malloc' function. */
+#mesondefine HAVE__ALIGNED_MALLOC
+
 /* Define if you have InitOnceExecuteOnce */
 #mesondefine HAVE_INIT_ONCE
 


### PR DESCRIPTION
Fixes #83 

MinGW also uses `_aligned_malloc()`, not just MSVC. Without this, we were just returning uninitialized memory since no other aligned allocator was available.

Also, use `G_GINT64_FORMAT` for printing `gint64` otherwise we get a segfault while printing.