### PR TITLE
Use malloc.h for _aligned_malloc instead of stdlib.h

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -130,7 +130,7 @@ conf.set('HAVE_MEMORY_H', cc.has_header('memory.h'))
 
 # Functions
 conf.set('HAVE_ALIGNED_ALLOC', cc.has_function('aligned_alloc', prefix: '#include <stdlib.h>'))
-conf.set('HAVE__ALIGNED_MALLOC', cc.has_function('_aligned_malloc', prefix: '#include <stdlib.h>'))
+conf.set('HAVE__ALIGNED_MALLOC', cc.has_function('_aligned_malloc', prefix: '#include <malloc.h>'))
 conf.set('HAVE_MEMALIGN', cc.has_function('memalign', prefix: '#include <stdlib.h>\n#include <malloc.h>'))
 conf.set('HAVE_POSIX_MEMALIGN', cc.has_function('posix_memalign', prefix: '#include <stdlib.h>'))
 conf.set('HAVE_SINCOSF', cc.has_function('sincosf', prefix: '#define _GNU_SOURCE\n#include <math.h>'))

--- a/src/bench/matrix.c
+++ b/src/bench/matrix.c
@@ -4,13 +4,13 @@
 #define _XOPEN_SOURCE 600
 #endif
 
-#if defined(HAVE_MEMALIGN) || (defined(HAVE__ALIGNED_MALLOC) && defined (_MSC_VER))
-/* MSVC Builds: Required for _aligned_malloc() and _aligned_free() */
+#if defined(HAVE_MEMALIGN) || defined(HAVE__ALIGNED_MALLOC)
+/* Required for _aligned_malloc() and _aligned_free() on Windows */
 #include <malloc.h>
 #endif
 
 #ifdef HAVE__ALIGNED_MALLOC
-/* On Visual Studio and MinGW, _aligned_malloc() takes in parameters in
+/* On Windows, we have to use _aligned_malloc() which takes in parameters in
  * inverted order from aligned_alloc(), but things are more or less the same
  * there otherwise
  */

--- a/src/graphene-alloc.c
+++ b/src/graphene-alloc.c
@@ -28,7 +28,12 @@
 # define _XOPEN_SOURCE 600
 #endif
 
-#ifdef _MSC_VER
+#if defined(HAVE_MEMALIGN) || defined(HAVE__ALIGNED_MALLOC)
+/* Required for _aligned_malloc() and _aligned_free() on Windows */
+#include <malloc.h>
+#endif
+
+#ifdef HAVE__ALIGNED_MALLOC
   /* _aligned_malloc() takes parameters of aligned_malloc() in reverse order */
 # define aligned_alloc(alignment,size) _aligned_malloc (size, alignment)
 
@@ -92,7 +97,7 @@ graphene_aligned_alloc (size_t size,
 
 #if defined(HAVE_POSIX_MEMALIGN)
   errno = posix_memalign (&res, alignment, real_size);
-#elif defined(HAVE_ALIGNED_ALLOC) || defined (_MSC_VER)
+#elif defined(HAVE_ALIGNED_ALLOC) || defined (HAVE__ALIGNED_MALLOC)
   /* real_size must be a multiple of alignment */
   if (real_size % alignment != 0)
     {


### PR DESCRIPTION
Fixes https://github.com/ebassi/graphene/pull/84#discussion_r90875361

Both `stdlib.h` and `malloc.h` define it on MinGW but it's only defined by `malloc.h` on MSVC, so just use `malloc.h`.

There are more issues needed for MSVC support, but this should help.