### PR TITLE
Use _aligned_malloc

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -130,7 +130,7 @@ conf.set('HAVE_MEMORY_H', cc.has_header('memory.h'))
 
 # Functions
 conf.set('HAVE_ALIGNED_ALLOC', cc.has_function('aligned_alloc', prefix: '#include <stdlib.h>'))
-conf.set('HAVE__ALIGNED_MALLOC', cc.has_function('_aligned_malloc', prefix: '#include <stdlib.h>'))
+conf.set('HAVE__ALIGNED_MALLOC', cc.has_function('_aligned_malloc', prefix: '#include <malloc.h>'))
 conf.set('HAVE_MEMALIGN', cc.has_function('memalign', prefix: '#include <stdlib.h>\n#include <malloc.h>'))
 conf.set('HAVE_POSIX_MEMALIGN', cc.has_function('posix_memalign', prefix: '#include <stdlib.h>'))
 conf.set('HAVE_SINCOSF', cc.has_function('sincosf', prefix: '#define _GNU_SOURCE\n#include <math.h>'))

--- a/src/bench/matrix.c
+++ b/src/bench/matrix.c
@@ -50,10 +50,13 @@ alloc_align (gsize n,
   gsize real_size = size * n;
   gpointer res;
 
-#if defined(HAVE_POSIX_MEMALIGN)
+#if defined (HAVE__ALIGNED_MALLOC)
+  g_assert (real_size % alignment == 0);
+  res = _aligned_malloc (real_size, alignment);
+#elif defined(HAVE_POSIX_MEMALIGN)
   if (posix_memalign (&res, alignment, real_size) != 0)
     g_assert_not_reached ();
-#elif defined(HAVE_ALIGNED_ALLOC) || defined (HAVE__ALIGNED_MALLOC)
+#elif defined(HAVE_ALIGNED_ALLOC)
   g_assert (real_size % alignment == 0);
   res = aligned_alloc (alignment, real_size);
 #elif defined(HAVE_MEMALIGN)

--- a/src/graphene-alloc.c
+++ b/src/graphene-alloc.c
@@ -90,7 +90,9 @@ graphene_aligned_alloc (size_t size,
   errno = 0;
 #endif
 
-#if defined(HAVE_POSIX_MEMALIGN)
+#if defined(HAVE__ALIGNED_MALLOC)
+  res = _aligned_malloc(real_size, alignment);
+#elif defined(HAVE_POSIX_MEMALIGN)
   errno = posix_memalign (&res, alignment, real_size);
 #elif defined(HAVE_ALIGNED_ALLOC) || defined (_MSC_VER)
   /* real_size must be a multiple of alignment */


### PR DESCRIPTION
This appears to be needed to get the build a little further on in MSYS2. It is entirely untested.

Proposed changes:

 - Look for _aligned_malloc in the correct place for MSVC and MSYS2 (see ref)
- Actually use _aligned_malloc().
  - used in preference to posix_memalign() because posix_memalign is still incorrectly detected on this system possibly as the result of an incorrectly exposed __builtin_posix_memalign.

Benchmark results:

- Cannot build yet, sorry. Next hurdle for me is the `g-ir-scanner` line, which may be too long for meson to handle.

Test suite changes:

 - Amended src/bench/matrix.c