### PR TITLE
Use only one aligned alloc func, work around msys2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -129,10 +129,21 @@ conf.set('HAVE_STDBOOL_H', cc.has_header('stdbool.h'))
 conf.set('HAVE_MEMORY_H', cc.has_header('memory.h'))
 
 # Functions
-conf.set('HAVE_ALIGNED_ALLOC', cc.has_function('aligned_alloc', prefix: '#include <stdlib.h>'))
-conf.set('HAVE__ALIGNED_MALLOC', cc.has_function('_aligned_malloc', prefix: '#include <malloc.h>'))
-conf.set('HAVE_MEMALIGN', cc.has_function('memalign', prefix: '#include <stdlib.h>\n#include <malloc.h>'))
-conf.set('HAVE_POSIX_MEMALIGN', cc.has_function('posix_memalign', prefix: '#include <stdlib.h>'))
+if cc.has_function('memalign', prefix: '#include <stdlib.h>\n#include <malloc.h>')
+  conf.set('HAVE_MEMALIGN', 1)
+elif cc.has_function('_aligned_malloc', prefix: '#include <malloc.h>')
+  conf.set('HAVE__ALIGNED_MALLOC', 1)
+# Don't probe the ones below on Windows because when building with
+# MinGW-w64 on MSYS2, Meson<0.37.0 incorrectly detects those below as
+# being available even though they're not.
+elif cc.has_function('aligned_alloc', prefix: '#include <stdlib.h>') and not (host_system == 'windows')
+  conf.set('HAVE_ALIGNED_ALLOC', 1)
+elif cc.has_function('posix_memalign', prefix: '#include <stdlib.h>') and not (host_system == 'windows')
+  conf.set('HAVE_POSIX_MEMALIGN', 1)
+else
+  error('No aligned malloc function could be found.')
+endif
+
 conf.set('HAVE_SINCOSF', cc.has_function('sincosf', prefix: '#define _GNU_SOURCE\n#include <math.h>'))
 
 # Debugging


### PR DESCRIPTION
Fixes #76.

Proposed changes:

- Cascading tests for the aligned malloc func as recommended by @nirbheek 
- Workaround for compilation on MSYS2: a hopefully temporary platform check

Benchmark results:

- Still cannot compile on Win32 (blocked by #88)

Test suite changes:

 - None

----------------

As recommended by @nirbheek, only search for a single aligned memory
allocation function: https://github.com/ebassi/graphene/pull/86#issuecomment-264900534

The cascade of tests means we can exclude the ones for which MSYS2's
native mingw-w64 builtins and headers conspire to provide meson with a
dud test. Although it is still not clear that meson is doing the right
thing in this case (mesonbuild/meson#1083), we can work around the
failed build in graphene by excluding certain POSIXy cases on Windows.

Closes ebassi/graphene#76, leaving ebassi/graphene#88 unsolved.