### PR TITLE
autotools: Use Python to invoke identfilter.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
     - gcc-4.8
     - libglib2.0-0
     - libglib2.0-dev
+    - python3
 
 sudo: false
 

--- a/configure.ac
+++ b/configure.ac
@@ -482,6 +482,9 @@ dnl === GObject introspection =================================================
 
 AS_IF([test "x$build_gobject" = xyes], [
   GOBJECT_INTROSPECTION_CHECK([gi_req_version])
+  # Any modern Python version will do for src/identfilter.py
+  AC_PATH_PROGS([PYTHON3_PATH], [python3 python3.5 python3.4 python3.3 python3.2 python3.1, python3.0])
+  AS_IF([test "x$PYTHON3_PATH" = "x"], [AC_MSG_ERROR([Cannot build introspection data without Python3])])
 ], [
   AM_CONDITIONAL(HAVE_INTROSPECTION, [false])
   enable_introspection=disabled

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -154,7 +154,7 @@ INTROSPECTION_GIRS = Graphene-1.0.gir
 introspection_source_h = $(filter-out graphene-simd4f.h graphene-simd4x4f.h,$(source_h))
 introspection_source_c = $(filter-out graphene-simd4f.c graphene-simd4x4f.c,$(source_c))
 
-filter_cmd = "$(top_srcdir)/src/identfilter.py"
+filter_cmd = "$(PYTHON3_PATH)" "$(top_srcdir)/src/identfilter.py"
 
 Graphene-1.0.gir: libgraphene-1.0.la $(top_srcdir)/src/identfilter.py Makefile
 


### PR DESCRIPTION
> We cannot rely on a shebang line on different platforms.
>
> Fixes https://github.com/ebassi/graphene/issues/88 for autotools.

Addresses #88 again for autotools.

Proposed changes:

 - invoke Python directly just like a3a959bc0e3dc8393ba57ce47afd8383cc8c845a

Benchmark results:

 - I cannot get graphene to build with either autotools or meson yet, so I was not able to run the tests.

Test suite changes:

 - None. The build will fail in the absence of Python however (perhaps with a meaningful error message, even)
