### PR TITLE
Updated meson build files to ease API version change.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,8 @@ graphene_micro_version = version_array[2].to_int()
 
 graphene_api_version = '@0@.0'.format(graphene_major_version)
 
+graphene_string = '@0@-@1@'.format(meson.project_name(), graphene_api_version)
+
 # The interface age is reset every time we add new API; this
 # should only happen during development cycles, otherwise the
 # interface age is the same as the micro version
@@ -181,6 +183,7 @@ endif
 # Optional dependency on GObject
 build_gobject = false
 if get_option('enable-gobject-types')
+  graphene_gobject_string = '@0@-gobject-@1@'.format(meson.project_name(), graphene_api_version)
   gobject = dependency('gobject-2.0', version: '>= 2.30.0', required: false)
   build_gobject = gobject.found()
   if build_gobject

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@ graphene_micro_version = version_array[2].to_int()
 
 graphene_api_version = '@0@.0'.format(graphene_major_version)
 
-graphene_string = '@0@-@1@'.format(meson.project_name(), graphene_api_version)
+graphene_api_path = '@0@-@1@'.format(meson.project_name(), graphene_api_version)
 
 # The interface age is reset every time we add new API; this
 # should only happen during development cycles, otherwise the
@@ -183,7 +183,7 @@ endif
 # Optional dependency on GObject
 build_gobject = false
 if get_option('enable-gobject-types')
-  graphene_gobject_string = '@0@-gobject-@1@'.format(meson.project_name(), graphene_api_version)
+  graphene_gobject_api_path = '@0@-gobject-@1@'.format(meson.project_name(), graphene_api_version)
   gobject = dependency('gobject-2.0', version: '>= 2.30.0', required: false)
   build_gobject = gobject.found()
   if build_gobject

--- a/src/meson.build
+++ b/src/meson.build
@@ -83,11 +83,11 @@ configure_file(input: 'graphene-version.h.in',
 
 install_headers(headers + simd_headers + [ 'graphene.h' ], subdir: graphene_api_path)
 
-pkgconfig_files = [ graphene_string ]
+pkgconfig_files = [ graphene_api_path ]
 platform_deps = []
 
 if build_gobject
-  pkgconfig_files += [ graphene_gobject_string ]
+  pkgconfig_files += [ graphene_gobject_api_path ]
   platform_deps += [ gobject ]
 endif
 
@@ -100,7 +100,7 @@ endif
 libtype = get_option('default_library')
 
 if libtype != 'static'
-  graphene_shared = shared_library(graphene_string,
+  graphene_shared = shared_library(graphene_api_path,
                                    sources: sources + simd_sources + private_headers,
                                    version: libversion,
                                    soversion: soversion,

--- a/src/meson.build
+++ b/src/meson.build
@@ -72,22 +72,22 @@ configure_file(input: 'graphene-config.h.meson',
                output: 'graphene-config.h',
                configuration: graphene_conf,
                install: true,
-               install_dir: join_paths(graphene_libdir, 'graphene-1.0', 'include'))
+               install_dir: join_paths(graphene_libdir, graphene_string, 'include'))
 
 # Version header
 configure_file(input: 'graphene-version.h.in',
                output: 'graphene-version.h',
                configuration: conf,
                install: true,
-               install_dir: join_paths(graphene_includedir, 'graphene-1.0'))
+               install_dir: join_paths(graphene_includedir, graphene_string))
 
-install_headers(headers + simd_headers + [ 'graphene.h' ], subdir: 'graphene-1.0')
+install_headers(headers + simd_headers + [ 'graphene.h' ], subdir: graphene_string)
 
-pkgconfig_files = [ 'graphene-@0@'.format(graphene_api_version) ]
+pkgconfig_files = [ graphene_string ]
 platform_deps = []
 
 if build_gobject
-  pkgconfig_files += [ 'graphene-gobject-@0@'.format(graphene_api_version) ]
+  pkgconfig_files += [ graphene_gobject_string ]
   platform_deps += [ gobject ]
 endif
 
@@ -100,7 +100,7 @@ endif
 libtype = get_option('default_library')
 
 if libtype != 'static'
-  graphene_shared = shared_library('graphene-@0@'.format(graphene_api_version),
+  graphene_shared = shared_library(graphene_string,
                                    sources: sources + simd_sources + private_headers,
                                    version: libversion,
                                    soversion: soversion,
@@ -118,7 +118,7 @@ if libtype != 'static'
 endif
 
 if libtype != 'shared'
-  graphene_static = static_library('graphene-@0@'.format(graphene_api_version),
+  graphene_static = static_library(graphene_string,
                                    sources: sources + simd_sources + private_headers,
                                    install: true,
                                    dependencies: [ mathlib, threadlib ] + platform_deps,
@@ -164,7 +164,7 @@ if build_gir
                      nsversion: graphene_api_version,
                      identifier_prefix: 'Graphene',
                      symbol_prefix: 'graphene',
-                     export_packages: 'graphene-gobject-@0@'.format(graphene_api_version),
+                     export_packages: graphene_gobject_string,
                      includes: [ 'GObject-2.0' ],
                      install: true,
                      extra_args: gir_extra_args)

--- a/src/meson.build
+++ b/src/meson.build
@@ -72,16 +72,16 @@ configure_file(input: 'graphene-config.h.meson',
                output: 'graphene-config.h',
                configuration: graphene_conf,
                install: true,
-               install_dir: join_paths(graphene_libdir, graphene_string, 'include'))
+               install_dir: join_paths(graphene_libdir, graphene_api_path, 'include'))
 
 # Version header
 configure_file(input: 'graphene-version.h.in',
                output: 'graphene-version.h',
                configuration: conf,
                install: true,
-               install_dir: join_paths(graphene_includedir, graphene_string))
+               install_dir: join_paths(graphene_includedir, graphene_api_path))
 
-install_headers(headers + simd_headers + [ 'graphene.h' ], subdir: graphene_string)
+install_headers(headers + simd_headers + [ 'graphene.h' ], subdir: graphene_api_path)
 
 pkgconfig_files = [ graphene_string ]
 platform_deps = []
@@ -118,7 +118,7 @@ if libtype != 'static'
 endif
 
 if libtype != 'shared'
-  graphene_static = static_library(graphene_string,
+  graphene_static = static_library(graphene_api_path,
                                    sources: sources + simd_sources + private_headers,
                                    install: true,
                                    dependencies: [ mathlib, threadlib ] + platform_deps,
@@ -164,7 +164,7 @@ if build_gir
                      nsversion: graphene_api_version,
                      identifier_prefix: 'Graphene',
                      symbol_prefix: 'graphene',
-                     export_packages: graphene_gobject_string,
+                     export_packages: graphene_gobject_api_path,
                      includes: [ 'GObject-2.0' ],
                      install: true,
                      extra_args: gir_extra_args)

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -22,8 +22,8 @@ unit_tests = [
 python = python3.find_python()
 gen_installed_test = join_paths(meson.current_source_dir(), 'gen-installed-test.py')
 
-installed_test_datadir = join_paths(get_option('prefix'), get_option('datadir'), 'installed-tests', graphene_string)
-installed_test_bindir = join_paths(get_option('prefix'), get_option('libexecdir'), 'installed-tests', graphene_string)
+installed_test_datadir = join_paths(get_option('prefix'), get_option('datadir'), 'installed-tests', graphene_api_path)
+installed_test_bindir = join_paths(get_option('prefix'), get_option('libexecdir'), 'installed-tests', graphene_api_path)
 
 foreach unit: unit_tests
   wrapper = '@0@.test'.format(unit)

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -22,8 +22,8 @@ unit_tests = [
 python = python3.find_python()
 gen_installed_test = join_paths(meson.current_source_dir(), 'gen-installed-test.py')
 
-installed_test_datadir = join_paths(get_option('prefix'), get_option('datadir'), 'installed-tests', 'graphene-1.0')
-installed_test_bindir = join_paths(get_option('prefix'), get_option('libexecdir'), 'installed-tests', 'graphene-1.0')
+installed_test_datadir = join_paths(get_option('prefix'), get_option('datadir'), 'installed-tests', graphene_string)
+installed_test_bindir = join_paths(get_option('prefix'), get_option('libexecdir'), 'installed-tests', graphene_string)
 
 foreach unit: unit_tests
   wrapper = '@0@.test'.format(unit)


### PR DESCRIPTION
meson build files have been changed to include a variable with graphene string to be used instead of hard coded strings.

Fixes #101

Proposed changes:

 - Changed the version number handling for generated files and directories in the meson build files.

Benchmark results:

 - Before: ...
 - After: ...

Test suite changes:

 - ...
