### PR TITLE
Fix Xcode-9 compile error

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -104,7 +104,7 @@ endif
 
 # Maintain compatibility with Autotools on macOS
 if host_machine.system().contains('darwin')
-  graphene_link_args += [ '-compatibility_version=1', '-current_version=1.0', ]
+  graphene_link_args += [ '-compatibility_version 1', '-current_version 1.0', ]
 endif
 
 libtype = get_option('default_library')


### PR DESCRIPTION
Apple's clang-9 (no idea what that maps to in clang's normal version) doesn't like an '=' in the version flags.

Fixes #...

Proposed changes:

 - ...

Benchmark results:

 - Before: ...
 - After: ...

Test suite changes:

 - ...
