### PR TITLE
Check pre-processor symbols

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -103,6 +103,7 @@ else
     '-Werror=return-type',
     '-Werror=array-bounds',
     '-Werror=write-strings',
+    '-Werror=undef',
   ]
 endif
 

--- a/src/graphene-box.c
+++ b/src/graphene-box.c
@@ -42,14 +42,14 @@
 #include <math.h>
 #include <stdio.h>
 
-#if HAVE_PTHREAD
+#ifdef HAVE_PTHREAD
 #include <pthread.h>
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
 #endif
 
-#if HAVE_INIT_ONCE
+#ifdef HAVE_INIT_ONCE
 #define _WIN32_WINNT 0x0600
 #include <windows.h>
 #endif
@@ -664,7 +664,7 @@ init_static_box_once (void)
   static_box[BOX_EMPTY].max.value = graphene_simd4f_init (-INFINITY, -INFINITY, -INFINITY, 0.f);
 }
 
-#if HAVE_PTHREAD
+#ifdef HAVE_PTHREAD
 static pthread_once_t static_box_once = PTHREAD_ONCE_INIT;
 
 static inline void
@@ -682,7 +682,7 @@ init_static_box (void)
     }
 }
 
-#elif HAVE_INIT_ONCE
+#elif defined(HAVE_INIT_ONCE)
 static INIT_ONCE static_box_once = INIT_ONCE_STATIC_INIT;
 
 BOOL CALLBACK

--- a/src/graphene-config.h.meson
+++ b/src/graphene-config.h.meson
@@ -12,7 +12,10 @@ extern "C" {
 
 #ifndef GRAPHENE_SIMD_BENCHMARK
 
-# if defined(__SSE__) || (_M_IX86_FP > 0) || (_M_X64 > 0) || (_MSC_VER >= 1800)
+# if defined(__SSE__) || \
+   (defined(_M_IX86_FP) && (_M_IX86_FP > 0)) || \
+   (defined(_M_X64) && (_M_X64 > 0)) || \
+   (defined(_MSC_VER) && (_MSC_VER >= 1800))
 #mesondefine GRAPHENE_HAS_SSE
 # endif
 

--- a/src/graphene-point3d.c
+++ b/src/graphene-point3d.c
@@ -109,7 +109,7 @@ graphene_point3d_init_from_simd4f (graphene_point3d_t      *p,
    * compiler check here. Clang 3.5 and GCC are perfectly happy with it,
    * but Travis-CI still uses Clang 3.4.
    */
-#if defined(__clang__) && __clang_major__ < 3 || (__clang_major__ == 3 && __clang_minor__ < 5)
+#if defined(__clang_major__) && (__clang_major__ < 3 || (__clang_major__ == 3 && __clang_minor__ < 5))
   p->x = graphene_simd4f_get (v, 0);
   p->y = graphene_simd4f_get (v, 1);
   p->z = graphene_simd4f_get (v, 2);

--- a/src/graphene-vectors.c
+++ b/src/graphene-vectors.c
@@ -27,14 +27,14 @@
 
 #include <stdio.h>
 
-#if HAVE_PTHREAD
+#ifdef HAVE_PTHREAD
 #include <pthread.h>
 #include <errno.h>
 #include <string.h>
 #include <stdio.h>
 #endif
 
-#if HAVE_INIT_ONCE
+#ifdef HAVE_INIT_ONCE
 #define _WIN32_WINNT 0x0600
 #include <windows.h>
 #endif
@@ -483,7 +483,7 @@ init_static_vec2_once (void)
   static_vec2[VEC2_Y_AXIS].value = graphene_simd4f_init (0.f, 1.f, 0.f, 0.f);
 }
 
-#if HAVE_PTHREAD
+#ifdef HAVE_PTHREAD
 static pthread_once_t static_vec2_once = PTHREAD_ONCE_INIT;
 
 static inline void
@@ -501,7 +501,7 @@ init_static_vec2 (void)
     }
 }
 
-#elif HAVE_INIT_ONCE
+#elif defined(HAVE_INIT_ONCE)
 static INIT_ONCE static_vec2_once = INIT_ONCE_STATIC_INIT;
 
 BOOL CALLBACK
@@ -1164,7 +1164,7 @@ init_static_vec3_once (void)
   static_vec3[VEC3_Z_AXIS].value = graphene_simd4f_init (0.f, 0.f, 1.f, 0.f);
 }
 
-#if HAVE_PTHREAD
+#ifdef HAVE_PTHREAD
 static pthread_once_t static_vec3_once = PTHREAD_ONCE_INIT;
 
 static inline void
@@ -1182,7 +1182,7 @@ init_static_vec3 (void)
     }
 }
 
-#elif HAVE_INIT_ONCE
+#elif defined(HAVE_INIT_ONCE)
 static INIT_ONCE static_vec3_once = INIT_ONCE_STATIC_INIT;
 
 BOOL CALLBACK
@@ -1863,7 +1863,7 @@ init_static_vec4_once (void)
   static_vec4[VEC4_W_AXIS].value = graphene_simd4f_init (0.f, 0.f, 0.f, 1.f);
 }
 
-#if HAVE_PTHREAD
+#ifdef HAVE_PTHREAD
 static pthread_once_t static_vec4_init_once = PTHREAD_ONCE_INIT;
 
 static inline void
@@ -1881,7 +1881,7 @@ init_static_vec4 (void)
     }
 }
 
-#elif HAVE_INIT_ONCE
+#elif defined(HAVE_INIT_ONCE)
 static INIT_ONCE static_vec4_once = INIT_ONCE_STATIC_INIT;
 
 BOOL CALLBACK


### PR DESCRIPTION
We're using a bunch of pre-processor symbols before checking if they are defined, which makes it hard to build Graphene if compiler flags like `-Wundef` are used.

Fixes #114