### PR TITLE
appveyor: Add MSYS2 jobs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,16 +4,23 @@ image: Visual Studio 2015
 
 configuration: Release
 
-# Configure both 32-bit and 64-bit builds
+# Configure both 32-bit and 64-bit builds for MSVC / MSYS2
 environment:
   matrix:
-  - MSVC_PLATFORM: x86
-  - MSVC_PLATFORM: x64
+    - MSVC_PLATFORM: x86
+      DO_DEPLOY: true
+    - MSVC_PLATFORM: x64
+      DO_DEPLOY: true
+    - MSYSTEM: MINGW64
+    - MSYSTEM: MINGW32
 
 shallow_clone: true
 
 build_script:
   - IF DEFINED MSVC_PLATFORM ".appveyor/msvc.bat"
+  - IF DEFINED MSYSTEM set CHERE_INVOKING=yes
+  - IF DEFINED MSYSTEM C:\msys64\usr\bin\bash -lc "bash -x .appveyor/msys2-pre.sh"
+  - IF DEFINED MSYSTEM C:\msys64\usr\bin\bash -lc "bash -x .appveyor/msys2.sh"
 
 artifacts:
   - path: graphene-shared-%MSVC_PLATFORM%.zip
@@ -33,3 +40,4 @@ deploy:
   prerelease: false
   on:
     appveyor_repo_tag: true # deploy on tag push only
+    DO_DEPLOY: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,50 +7,17 @@ configuration: Release
 # Configure both 32-bit and 64-bit builds
 environment:
   matrix:
-  - platform: x86
-    config: Win32
-    pout: x86
-  - platform: x64
-    config: x64
-    pout: x64
+  - MSVC_PLATFORM: x86
+  - MSVC_PLATFORM: x64
 
 shallow_clone: true
 
-# Download Meson and Ninja, create install directory
-before_build:
-- mkdir _build
-- mkdir graphene-shared-%pout%
-- cd _build
-- curl -LsSO https://github.com/mesonbuild/meson/releases/download/0.44.1/meson-0.44.1.tar.gz
-- 7z x meson-0.44.1.tar.gz
-- move dist\meson-0.44.1.tar .
-- 7z x meson-0.44.1.tar
-- rmdir dist
-- del meson-0.44.1.tar meson-0.44.1.tar.gz
-- curl -LsSO https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip
-- 7z x ninja-win.zip
-- del ninja-win.zip
-- cd ..
-
-# Build and install
 build_script:
-- cd _build
-- call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %PLATFORM%
-- C:\Python36\python.exe meson-0.44.1\meson.py .. . --backend=ninja --prefix=%APPVEYOR_BUILD_FOLDER%\graphene-shared-%pout%
-- ninja
-- ninja test
-- ninja install
-- cd ..
-
-# Copy license into install directory and create .zip file
-after_build:
-- copy LICENSE graphene-shared-%pout%
-- dir graphene-shared-%pout% /s /b
-- 7z a -tzip graphene-shared-%pout%.zip graphene-shared-%pout%
+  - IF DEFINED MSVC_PLATFORM ".appveyor/msvc.bat"
 
 artifacts:
-  - path: graphene-shared-%pout%.zip
-    name: graphene-shared-%pout%
+  - path: graphene-shared-%MSVC_PLATFORM%.zip
+    name: graphene-shared-%MSVC_PLATFORM%
 
 test: off
 
@@ -61,7 +28,7 @@ deploy:
   provider: GitHub
   auth_token:
     secure: X7Ro8Y2RWYo/M1AAn93f9X0dEQFvu7gPb6li2eKRtzPYLGj/JKm7MNWRw2cCcjm6
-  artifact: graphene-shared-$(pout)
+  artifact: graphene-shared-$(MSVC_PLATFORM)
   draft: false
   prerelease: false
   on:

--- a/.appveyor/msvc.bat
+++ b/.appveyor/msvc.bat
@@ -1,0 +1,36 @@
+@echo on
+
+:: Download Meson and Ninja, create install directory
+mkdir _build
+mkdir graphene-shared-%MSVC_PLATFORM%
+cd _build
+curl -LsSO https://github.com/mesonbuild/meson/releases/download/0.44.1/meson-0.44.1.tar.gz
+7z x meson-0.44.1.tar.gz
+move dist\meson-0.44.1.tar .
+7z x meson-0.44.1.tar
+rmdir dist
+del meson-0.44.1.tar meson-0.44.1.tar.gz
+curl -LsSO https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip
+7z x ninja-win.zip
+del ninja-win.zip
+cd ..
+
+:: Build and install
+cd _build
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %MSVC_PLATFORM%
+@echo on
+C:\Python36\python.exe meson-0.44.1\meson.py .. . --backend=ninja --prefix=%APPVEYOR_BUILD_FOLDER%\graphene-shared-%MSVC_PLATFORM% || goto :error
+ninja || goto :error
+ninja test || goto :error
+ninja install || goto :error
+cd ..
+
+:: Copy license into install directory and create .zip file
+copy LICENSE graphene-shared-%MSVC_PLATFORM% || goto :error
+dir graphene-shared-%MSVC_PLATFORM% /s /b || goto :error
+7z a -tzip graphene-shared-%MSVC_PLATFORM%.zip graphene-shared-%MSVC_PLATFORM% || goto :error
+
+goto :EOF
+
+:error
+exit /b 1

--- a/.appveyor/msys2-pre.sh
+++ b/.appveyor/msys2-pre.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+# Disable slow diskspace check
+sed -i 's/^CheckSpace/#CheckSpace/g' /etc/pacman.conf
+
+# System upgrade
+pacman --noconfirm -Syyuu

--- a/.appveyor/msys2.sh
+++ b/.appveyor/msys2.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+if [[ "$MSYSTEM" == "MINGW32" ]]; then
+    export MSYS2_ARCH="i686"
+else
+    export MSYS2_ARCH="x86_64"
+fi
+
+# Update everything
+pacman --noconfirm -Suy
+
+# Install the required packages
+pacman --noconfirm -S --needed \
+    base-devel \
+    mingw-w64-$MSYS2_ARCH-toolchain \
+    mingw-w64-$MSYS2_ARCH-meson \
+    mingw-w64-$MSYS2_ARCH-ninja \
+    mingw-w64-$MSYS2_ARCH-pkg-config \
+    mingw-w64-$MSYS2_ARCH-gobject-introspection
+
+# Build
+meson _build
+cd _build
+ninja
+
+# Test
+meson test


### PR DESCRIPTION
Context: https://github.com/ebassi/graphene/issues/114#issuecomment-379840661

The first commit moves the MSVC commands into a separate file, the second one adds MSYS2 support.

Sadly every build goes through all commands so you either have to do lots of ifs everywhere or move things to batch/shell files. And with batch files you have to do that goto stuff to get it to fail properly. But it seemed like less of a mess all in all.