### PR TITLE
Fix some MinGW warnings

### DIFF
--- a/src/graphene-box.c
+++ b/src/graphene-box.c
@@ -680,7 +680,7 @@ init_static_box (void)
 #elif defined(HAVE_INIT_ONCE)
 static INIT_ONCE static_box_once = INIT_ONCE_STATIC_INIT;
 
-BOOL CALLBACK
+static BOOL CALLBACK
 InitBoxFunc (PINIT_ONCE InitOnce,
              PVOID      param,
              PVOID     *ctx)

--- a/src/graphene-box.c
+++ b/src/graphene-box.c
@@ -49,11 +49,6 @@
 #include <errno.h>
 #endif
 
-#ifdef HAVE_INIT_ONCE
-#define _WIN32_WINNT 0x0600
-#include <windows.h>
-#endif
-
 /**
  * graphene_box_alloc: (constructor)
  *

--- a/src/graphene-private.h
+++ b/src/graphene-private.h
@@ -25,6 +25,10 @@
 #define __GRAPHENE_PRIVATE_H__
 
 #include "config.h"
+#ifdef HAVE_INIT_ONCE
+#define _WIN32_WINNT 0x0600
+#include <windows.h>
+#endif
 #include "graphene-macros.h"
 #include <stdlib.h>
 #include <math.h>

--- a/src/graphene-vectors.c
+++ b/src/graphene-vectors.c
@@ -499,7 +499,7 @@ init_static_vec2 (void)
 #elif defined(HAVE_INIT_ONCE)
 static INIT_ONCE static_vec2_once = INIT_ONCE_STATIC_INIT;
 
-BOOL CALLBACK
+static BOOL CALLBACK
 InitVec2Func (PINIT_ONCE InitOnce,
               PVOID      Parameter,
               PVOID     *lpContext)
@@ -1180,7 +1180,7 @@ init_static_vec3 (void)
 #elif defined(HAVE_INIT_ONCE)
 static INIT_ONCE static_vec3_once = INIT_ONCE_STATIC_INIT;
 
-BOOL CALLBACK
+static BOOL CALLBACK
 InitVec3Func (PINIT_ONCE InitOnce,
               PVOID      Parameter,
               PVOID     *lpContext)
@@ -1879,7 +1879,7 @@ init_static_vec4 (void)
 #elif defined(HAVE_INIT_ONCE)
 static INIT_ONCE static_vec4_once = INIT_ONCE_STATIC_INIT;
 
-BOOL CALLBACK
+static BOOL CALLBACK
 InitVec4Func (PINIT_ONCE InitOnce,
               PVOID      Parameter,
               PVOID     *lpContext)

--- a/src/graphene-vectors.c
+++ b/src/graphene-vectors.c
@@ -34,11 +34,6 @@
 #include <stdio.h>
 #endif
 
-#ifdef HAVE_INIT_ONCE
-#define _WIN32_WINNT 0x0600
-#include <windows.h>
-#endif
-
 /**
  * SECTION:graphene-vectors
  * @Title: Vectors


### PR DESCRIPTION
partly fixes #118 

I haven't figured out the SSE related warning (seems to be a real warning, enabling SSE on 32bit seems to change ABI and things crash until rebuild)