### PR TITLE
Disable SIMD optimizations on 32bit Intel Architectures

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -235,16 +235,16 @@ graphene_simd = []
 sse2_cflags = ''
 if get_option('sse2')
   sse_prog = '''
-#if defined(__GNUC__) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 2))
+#if defined(__GNUC__) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 9))
 # if !defined(__amd64__) && !defined(__x86_64__)
-#   error "Need GCC >= 4.2 for SSE2 intrinsics on x86"
+#   error "Need GCC >= 4.9 for SSE2 intrinsics on x86"
 # endif
 #elif defined (_MSC_VER) && (_MSC_VER < 1800)
 # if !defined (_M_X64) && !defined (_M_AMD64)
 #   error "Need MSVC 2013 or later for SSE2 intrinsics on x86"
 # endif
 #endif
-#if defined(__SSE__) || (_M_IX86_FP > 0) || (_M_X64 > 0) || (_MSC_VER >= 1800)
+#if defined(__SSE__) || (_M_X64 > 0) || (_MSC_VER >= 1800)
 # include <mmintrin.h>
 # include <xmmintrin.h>
 # include <emmintrin.h>
@@ -274,6 +274,8 @@ if get_option('gcc_vector')
 #   error "GCC vector intrinsics are disabled on GCC prior to 4.9"
 # elif defined(__arm__)
 #   error "GCC vector intrinsics are disabled on ARM"
+# elif !defined(__x86_64__)
+#   error "GCC vector intrinsics are disabled on 32bit"
 # endif
 #else
 # error "Need GCC for GCC vectors intrinsics"

--- a/src/graphene-config.h.meson
+++ b/src/graphene-config.h.meson
@@ -13,7 +13,6 @@ extern "C" {
 #ifndef GRAPHENE_SIMD_BENCHMARK
 
 # if defined(__SSE__) || \
-   (defined(_M_IX86_FP) && (_M_IX86_FP > 0)) || \
    (defined(_M_X64) && (_M_X64 > 0)) || \
    (defined(_MSC_VER) && (_MSC_VER >= 1800))
 #mesondefine GRAPHENE_HAS_SSE


### PR DESCRIPTION
SIMD implementations are terrible on 32bit IA for a variety of reasons:

 - SSE2+ intrinsics are generally unsupported except on very old CPU
   packages, and compilers are poorly optimized for those
 - GCC vectorization builtins require a decent version of GCC to begin
   with, and will likely work badly on 32 bit builds
 - allocators on 32bit are not capable of aligning SIMD-based
   structures, and no amount of trickery will allow them to work
   properly.

If you're building Graphene for 32 bit you're much better served by
using the scalar fallback code; it may be slow, but at least it'll work
as expected.