### PR TITLE
Fix point transformation

### DIFF
--- a/src/graphene-matrix.c
+++ b/src/graphene-matrix.c
@@ -861,6 +861,9 @@ graphene_matrix_transform_vec4 (const graphene_matrix_t *m,
  *
  * Transforms the given #graphene_point_t using the matrix @m.
  *
+ * Unlike graphene_matrix_transform_vec3(), this function will take into
+ * account the fourth row vector of the #graphene_matrix_t.
+ *
  * Since: 1.0
  */
 void
@@ -870,8 +873,8 @@ graphene_matrix_transform_point (const graphene_matrix_t *m,
 {
   graphene_simd4f_t vec3;
 
-  vec3 = graphene_simd4f_init (p->x, p->y, 0.0f, 0.0f);
-  graphene_simd4x4f_vec3_mul (&m->value, &vec3, &vec3);
+  vec3 = graphene_simd4f_init (p->x, p->y, 0.0f, 1.0f);
+  graphene_simd4x4f_point3_mul (&m->value, &vec3, &vec3);
 
   res->x = graphene_simd4f_get_x (vec3);
   res->y = graphene_simd4f_get_y (vec3);
@@ -897,7 +900,7 @@ graphene_matrix_transform_point3d (const graphene_matrix_t  *m,
 {
   graphene_simd4f_t vec3;
 
-  vec3 = graphene_simd4f_init (p->x, p->y, p->z, 0.f);
+  vec3 = graphene_simd4f_init (p->x, p->y, p->z, 1.f);
   graphene_simd4x4f_point3_mul (&m->value, &vec3, &vec3);
 
   res->x = graphene_simd4f_get_x (vec3);

--- a/src/graphene-simd4x4f.h
+++ b/src/graphene-simd4x4f.h
@@ -248,7 +248,10 @@ graphene_simd4x4f_vec4_mul (const graphene_simd4x4f_t *a,
  *
  * Multiplies the given #graphene_simd4x4f_t with the given
  * #graphene_simd4f_t, using only the first three row vectors
- * of the matrix, and the first three components of the vector.
+ * of the matrix, and the first three components of the vector;
+ * the W components of the matrix and vector are ignored.
+ *
+ * See also: graphene_simd4x4_point3_mul()
  *
  * Since: 1.0
  */
@@ -276,7 +279,7 @@ graphene_simd4x4f_vec3_mul (const graphene_simd4x4f_t *m,
  * #graphene_simd4f_t.
  *
  * Unlike graphene_simd4x4f_vec3_mul(), this function will
- * also use the fourth row vector of the matrix.
+ * use the W components of the matrix and vector.
  *
  * Since: 1.0
  */

--- a/src/tests/graphene-test-compat.h
+++ b/src/tests/graphene-test-compat.h
@@ -108,6 +108,21 @@
     } \
   } G_STMT_END
 
+#define graphene_assert_fuzzy_point3d_equal(p1,p2,epsilon) \
+  G_STMT_START { \
+    graphene_point3d_t *__p1 = (p1); \
+    graphene_point3d_t *__p2 = (p2); \
+    float __epsilon = (epsilon); \
+    if (graphene_point3d_near (__p1, __p2, __epsilon)) ; \
+    else { \
+      char *s = g_strdup_printf (#p1 " == " #p2 " (+/- " #epsilon "): " \
+                                 "{ x:%.7g, y:%.7g, z:%.7g } == { x:%.7g, y:%.7g, z:%.7g }", \
+                                 __p1->x, __p1->y, __p1->z, __p2->x, __p2->y, __p2->z); \
+      g_assertion_message (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, s); \
+      g_free (s); \
+    } \
+  } G_STMT_END
+
 #define graphene_assert_fuzzy_size_equal(s1,s2,epsilon) \
   G_STMT_START { \
     if (graphene_fuzzy_equals ((s1)->width, (s2)->width, epsilon) && \

--- a/src/tests/matrix.c
+++ b/src/tests/matrix.c
@@ -502,6 +502,7 @@ GRAPHENE_TEST_UNIT_BEGIN (matrix_3d_transform_point)
 {
   graphene_matrix_t m;
   graphene_point_t p;
+  graphene_point3d_t p3;
   graphene_vec3_t v;
 
   graphene_matrix_init_translate (&m, &GRAPHENE_POINT3D_INIT (50.f, 70.f, 0.f));
@@ -510,6 +511,11 @@ GRAPHENE_TEST_UNIT_BEGIN (matrix_3d_transform_point)
   graphene_point_init (&p, 0.f, 0.f);
   graphene_matrix_transform_point (&m, &p, &p);
   graphene_assert_fuzzy_point_equal (&p, &GRAPHENE_POINT_INIT (50.f, 70.f), 0.01f);
+
+  g_test_message ("mat(translation) * point3d(zero) = point3d(translation)");
+  graphene_point3d_init (&p3, 0.f, 0.f, 0.f);
+  graphene_matrix_transform_point3d (&m, &p3, &p3);
+  graphene_assert_fuzzy_point3d_equal (&p3, &GRAPHENE_POINT3D_INIT (50.f, 70.f, 0.0f), 0.01f);
 
   g_test_message ("mat(translation) * vec3(zero) = vec3(zero)");
   graphene_vec3_init (&v, 0.f, 0.f, 0.f);

--- a/src/tests/matrix.c
+++ b/src/tests/matrix.c
@@ -498,6 +498,26 @@ GRAPHENE_TEST_UNIT_BEGIN (matrix_2d_transform_bound)
 }
 GRAPHENE_TEST_UNIT_END
 
+GRAPHENE_TEST_UNIT_BEGIN (matrix_3d_transform_point)
+{
+  graphene_matrix_t m;
+  graphene_point_t p;
+  graphene_vec3_t v;
+
+  graphene_matrix_init_translate (&m, &GRAPHENE_POINT3D_INIT (50.f, 70.f, 0.f));
+
+  g_test_message ("mat(translation) * point(zero) = point(translation)");
+  graphene_point_init (&p, 0.f, 0.f);
+  graphene_matrix_transform_point (&m, &p, &p);
+  graphene_assert_fuzzy_point_equal (&p, &GRAPHENE_POINT_INIT (50.f, 70.f), 0.01f);
+
+  g_test_message ("mat(translation) * vec3(zero) = vec3(zero)");
+  graphene_vec3_init (&v, 0.f, 0.f, 0.f);
+  graphene_matrix_transform_vec3 (&m, &v, &v);
+  graphene_assert_fuzzy_vec3_equal (&v, graphene_vec3_zero (), 0.01f);
+}
+GRAPHENE_TEST_UNIT_END
+
 GRAPHENE_TEST_SUITE (
   GRAPHENE_TEST_UNIT ("/matrix/identity", matrix_identity)
   GRAPHENE_TEST_UNIT ("/matrix/scale", matrix_scale)
@@ -513,4 +533,5 @@ GRAPHENE_TEST_SUITE (
   GRAPHENE_TEST_UNIT ("/matrix/2d/round-trip", matrix_2d_round_trip)
   GRAPHENE_TEST_UNIT ("/matrix/2d/interpolate", matrix_2d_interpolate)
   GRAPHENE_TEST_UNIT ("/matrix/2d/transform_bound", matrix_2d_transform_bound)
+  GRAPHENE_TEST_UNIT ("/matrix/3d/transform_point", matrix_3d_transform_point)
 )


### PR DESCRIPTION
The transformation of 2D and 3D points should take into account the W row of the matrix, unlike transformations of vec3 vectors.

Currently, the `graphene_matrix_transform_point()` implementation calls into the matrix/vec3 multiplication, which is wrong; the `graphene_matrix_point3d()` implementation correctly calls into the matrix/point3 multiplication.

Additionally, the documentation is less than clear as to which API is meant to ignore the W components of both the matrix and the vector, and which API is meant to take into account the W row of the matrix alone.

Test suite changes:

 - Added a new unit to verify that matrix/point and matrix/point3d transformations are different than matrix/vec3 transformations.