### PR TITLE
bench: Fix MSVC build error on 32-bit Windows

### DIFF
--- a/src/bench/graphene-bench-utils.c
+++ b/src/bench/graphene-bench-utils.c
@@ -166,7 +166,7 @@ static double
 graphene_bench_run_test (const char *impl,
                          const char *path,
                          GrapheneBenchFunc func,
-                         gint64 num_rounds,
+                         int num_rounds,
                          double *round_min,
                          double *round_max,
                          double *round_avg)
@@ -224,7 +224,7 @@ graphene_bench_run_test (const char *impl,
   free (round_elapsed);
 
   if (bench_verbose)
-    g_printerr ("# '[%s]:%s': %.6f usecs/round after %" G_GINT64_FORMAT " rounds\n",
+    g_printerr ("# '[%s]:%s': %.6f usecs/round after %i rounds\n",
                 impl,
                 path,
                 elapsed,


### PR DESCRIPTION
`size_t` is `unsigned long int` which is a 32-bit integer on 32-bit Windows. The multiplication in `malloc()` below then evaluates to a 32-bit integer which the compiler complains about.

This is normally a warning, but since we use `-we4244` it's an error.

src/bench/graphene-bench-utils.c(175): error C4244: 'function': conversion from 'gint64' to 'size_t', possible loss of data`

The number of rounds will never exceed INT_MAX, so we can just use an int here.