### PR TITLE
build: don't hide the stdbool include from g-ir-scanner

### DIFF
--- a/src/graphene-macros.h
+++ b/src/graphene-macros.h
@@ -71,14 +71,12 @@
 # define GRAPHENE_END_DECLS
 #endif
 
-#ifndef __GI_SCANNER__
 #if defined(_MSC_VER) && !defined(__bool_true_false_are_defined) && (_MSC_VER < 1800)
 typedef int bool;
 # define false 0
 # define true 1
 #else
 # include <stdbool.h>
-#endif
 #endif
 
 #if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1)


### PR DESCRIPTION
g-i recently lost the ability to infer the bool type without a stdbool include.
While this is about to be fixed in g-i (https://gitlab.gnome.org/GNOME/gobject-introspection/merge_requests/116)
I don't see a reason why we should hide this in the first place, so remove the ifdef guard.