### PR TITLE
build: Do not use set10() for InitOnce checks

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -226,7 +226,7 @@ int main (void) {
   return 0;
 }
 '''
-  conf.set10('HAVE_INIT_ONCE',
+  conf.set('HAVE_INIT_ONCE',
     cc.compiles(init_once_prog, name: 'InitOnceExecuteOnce'),
     description: 'Define if InitOnceExecuteOnce is available',
   )


### PR DESCRIPTION
We use `#ifdef HAVE_INIT_ONCE` all over the place, and set10() will
unconditionally define the symbol, which means the check will always
succeed even if InitOnce and friends are not available.