### PR TITLE
simd4x4f: Use an intermediate for multiplication

### DIFF
--- a/src/graphene-simd4x4f.h
+++ b/src/graphene-simd4x4f.h
@@ -431,10 +431,14 @@ graphene_simd4x4f_matrix_mul (const graphene_simd4x4f_t *a,
    * the order is correct if we want to multiply A with B; remember
    * that matrix multiplication is non-commutative.
    */
-  graphene_simd4x4f_vec4_mul (b, &a->x, &res->x);
-  graphene_simd4x4f_vec4_mul (b, &a->y, &res->y);
-  graphene_simd4x4f_vec4_mul (b, &a->z, &res->z);
-  graphene_simd4x4f_vec4_mul (b, &a->w, &res->w);
+  graphene_simd4f_t x, y, z, w;
+
+  graphene_simd4x4f_vec4_mul (b, &a->x, &x);
+  graphene_simd4x4f_vec4_mul (b, &a->y, &y);
+  graphene_simd4x4f_vec4_mul (b, &a->z, &z);
+  graphene_simd4x4f_vec4_mul (b, &a->w, &w);
+
+  *res = graphene_simd4x4f_init (x, y, z, w);
 #endif
 }
 

--- a/src/tests/matrix.c
+++ b/src/tests/matrix.c
@@ -455,6 +455,33 @@ GRAPHENE_TEST_UNIT_BEGIN (matrix_interpolate)
 }
 GRAPHENE_TEST_UNIT_END
 
+GRAPHENE_TEST_UNIT_BEGIN (matrix_multiply_self)
+{
+  graphene_matrix_t a, b, res, test;
+  float floats[16] = { 0, 0, 0, 2,
+                       0, 0, 2, 0,
+                       0, 2, 0, 0,
+                       2, 0, 0, 0 };
+
+  graphene_matrix_init_from_float (&a, floats);
+  graphene_matrix_init_from_float (&b, floats);
+  graphene_matrix_multiply (&a, &b, &res);
+  graphene_matrix_print (&res);
+
+  graphene_matrix_init_from_float (&test, floats);
+  graphene_matrix_multiply (&test, &b, &test);
+  graphene_assert_fuzzy_matrix_equal (&test, &res, G_MINDOUBLE);
+
+  graphene_matrix_init_from_float (&test, floats);
+  graphene_matrix_multiply (&a, &test, &test);
+  graphene_assert_fuzzy_matrix_equal (&test, &res, G_MINDOUBLE);
+
+  graphene_matrix_init_from_float (&test, floats);
+  graphene_matrix_multiply (&test, &test, &test);
+  graphene_assert_fuzzy_matrix_equal (&test, &res, G_MINDOUBLE);
+}
+GRAPHENE_TEST_UNIT_END
+
 GRAPHENE_TEST_UNIT_BEGIN (matrix_2d_interpolate)
 {
   graphene_matrix_t m1, m2, m3, mr;
@@ -534,6 +561,7 @@ GRAPHENE_TEST_SUITE (
   GRAPHENE_TEST_UNIT ("/matrix/look_at", matrix_look_at)
   GRAPHENE_TEST_UNIT ("/matrix/invert", matrix_invert)
   GRAPHENE_TEST_UNIT ("/matrix/interpolate", matrix_interpolate)
+  GRAPHENE_TEST_UNIT ("/matrix/multiply_self", matrix_multiply_self)
   GRAPHENE_TEST_UNIT ("/matrix/2d/identity", matrix_2d_identity)
   GRAPHENE_TEST_UNIT ("/matrix/2d/transforms", matrix_2d_transforms)
   GRAPHENE_TEST_UNIT ("/matrix/2d/round-trip", matrix_2d_round_trip)


### PR DESCRIPTION
Otherwise if b == res, the row vectors will be overwritten while they
are still being used.

In particular, this fixes graphene_matrix_multiply (a, b, b) being
broken.

A new test, matrix/mutliply-self has been added.

Fixes #...

Proposed changes:

 - ...

Benchmark results:

 - Before: ...
 - After: ...

Test suite changes:

 - ...
