### PR TITLE
 matrix: Fix boolean logic in graphene_matrix_to_2d()

### DIFF
--- a/src/graphene-matrix.c
+++ b/src/graphene-matrix.c
@@ -629,38 +629,22 @@ graphene_matrix_to_2d (const graphene_matrix_t *m,
 {
   float res[4];
 
-  graphene_simd4f_dup_4f (m->value.x, res);
-  if (!graphene_approx_val (res[2], 0.f) &&
-      !graphene_approx_val (res[3], 0.f))
+  if (!graphene_simd4x4f_is_2d (&m->value))
     return false;
 
+  graphene_simd4f_dup_4f (m->value.x, res);
   if (xx != NULL)
     *xx = res[0];
   if (yx != NULL)
     *yx = res[1];
 
   graphene_simd4f_dup_4f (m->value.y, res);
-  if (!graphene_approx_val (res[2], 0.f) &&
-      !graphene_approx_val (res[3], 0.f))
-    return false;
-
   if (xy != NULL)
     *xy = res[0];
   if (yy != NULL)
     *yy = res[1];
 
-  graphene_simd4f_dup_4f (m->value.z, res);
-  if (!graphene_approx_val (res[0], 0.f) &&
-      !graphene_approx_val (res[1], 0.f) &&
-      !graphene_approx_val (res[2], 1.f) &&
-      !graphene_approx_val (res[3], 0.f))
-    return false;
-
   graphene_simd4f_dup_4f (m->value.w, res);
-  if (!graphene_approx_val (res[2], 0.f) &&
-      !graphene_approx_val (res[3], 1.f))
-    return false;
-
   if (x_0 != NULL)
     *x_0 = res[0];
   if (y_0 != NULL)

--- a/src/tests/matrix.c
+++ b/src/tests/matrix.c
@@ -466,7 +466,6 @@ GRAPHENE_TEST_UNIT_BEGIN (matrix_multiply_self)
   graphene_matrix_init_from_float (&a, floats);
   graphene_matrix_init_from_float (&b, floats);
   graphene_matrix_multiply (&a, &b, &res);
-  graphene_matrix_print (&res);
 
   graphene_matrix_init_from_float (&test, floats);
   graphene_matrix_multiply (&test, &b, &test);

--- a/src/tests/matrix.c
+++ b/src/tests/matrix.c
@@ -481,6 +481,30 @@ GRAPHENE_TEST_UNIT_BEGIN (matrix_multiply_self)
 }
 GRAPHENE_TEST_UNIT_END
 
+GRAPHENE_TEST_UNIT_BEGIN (matrix_to_2d)
+{
+  graphene_matrix_t matrix;
+  float f[16];
+  guint i;
+  bool valid[16] = {
+    true,  true,  false, false,
+    true,  true,  false, false,
+    false, false, false, false,
+    true,  true,  false, false };
+
+  for (i = 0; i < 16; i++)
+    {
+      /* Take the identity matrix and change one member to a different value */
+      graphene_matrix_init_identity (&matrix);
+      graphene_matrix_to_float (&matrix, f);
+      f[i] = 0.5f;
+      graphene_matrix_init_from_float (&matrix, f);
+
+      g_assert_cmpint (graphene_matrix_to_2d (&matrix, NULL, NULL, NULL, NULL, NULL, NULL), ==, valid[i]);
+    }
+}
+GRAPHENE_TEST_UNIT_END
+
 GRAPHENE_TEST_UNIT_BEGIN (matrix_2d_interpolate)
 {
   graphene_matrix_t m1, m2, m3, mr;
@@ -561,6 +585,7 @@ GRAPHENE_TEST_SUITE (
   GRAPHENE_TEST_UNIT ("/matrix/invert", matrix_invert)
   GRAPHENE_TEST_UNIT ("/matrix/interpolate", matrix_interpolate)
   GRAPHENE_TEST_UNIT ("/matrix/multiply_self", matrix_multiply_self)
+  GRAPHENE_TEST_UNIT ("/matrix/to-2d", matrix_to_2d)
   GRAPHENE_TEST_UNIT ("/matrix/2d/identity", matrix_2d_identity)
   GRAPHENE_TEST_UNIT ("/matrix/2d/transforms", matrix_2d_transforms)
   GRAPHENE_TEST_UNIT ("/matrix/2d/round-trip", matrix_2d_round_trip)


### PR DESCRIPTION
This looks like a thinko, where && and || where confused leading to way
too many matrices being accepted as 2D when they shouldn't.

A new test, matrix/is-2d has been added.