### PR TITLE
Rect rounding improvements

### DIFF
--- a/doc/graphene-sections.txt
+++ b/doc/graphene-sections.txt
@@ -348,6 +348,7 @@ graphene_rect_inset
 graphene_rect_inset_r
 graphene_rect_round_to_pixel
 graphene_rect_round
+graphene_rect_round_extents
 graphene_rect_expand
 graphene_rect_interpolate
 graphene_rect_zero

--- a/doc/graphene-sections.txt
+++ b/doc/graphene-sections.txt
@@ -336,6 +336,7 @@ graphene_rect_get_x
 graphene_rect_get_y
 graphene_rect_get_width
 graphene_rect_get_height
+graphene_rect_get_area
 graphene_rect_get_vertices
 graphene_rect_union
 graphene_rect_intersection

--- a/src/graphene-rect.c
+++ b/src/graphene-rect.c
@@ -736,7 +736,8 @@ graphene_rect_round_to_pixel (graphene_rect_t *r)
  *
  * Rounds the origin and size of the given rectangle to
  * their nearest integer values; the rounding is guaranteed
- * to be large enough to contain the original rectangle.
+ * to be large enough to have an area bigger or equal to the
+ * original rectangle, but might not fully contain its extents.
  *
  * This function is the equivalent of calling `floor` on
  * the coordinates of the origin, and `ceil` on the size.

--- a/src/graphene-rect.c
+++ b/src/graphene-rect.c
@@ -434,6 +434,26 @@ GRAPHENE_RECT_GET (r, size, height)
 #undef GRAPHENE_RECT_GET
 
 /**
+ * graphene_rect_get_area:
+ * @r: a #graphene_rect_t
+ *
+ * Compute the area of given normalized rectangle.
+ *
+ * Returns: the area of the normalized rectangle
+ *
+ * Since: 1.10
+ */
+float
+graphene_rect_get_area (const graphene_rect_t *r)
+{
+  graphene_rect_t rr;
+
+  graphene_rect_normalize_r (r, &rr);
+
+  return rr.size.width * rr.size.height;
+}
+
+/**
  * graphene_rect_union:
  * @a: a #graphene_rect_t
  * @b: a #graphene_rect_t

--- a/src/graphene-rect.c
+++ b/src/graphene-rect.c
@@ -764,9 +764,9 @@ graphene_rect_round_to_pixel (graphene_rect_t *r)
  * This function is the equivalent of calling `floor` on
  * the coordinates of the origin, and `ceil` on the size.
  *
- * See also: graphene_rect_round_extents()
- *
  * Since: 1.4
+ *
+ * Deprecated: 1.10: Use graphene_rect_round_extents() instead
  */
 void
 graphene_rect_round (const graphene_rect_t *r,
@@ -808,8 +808,6 @@ graphene_rect_round (const graphene_rect_t *r,
  * size, then the move of the origin would not be compensated
  * by a move in the anti-origin, leaving the corners of the
  * original rectangle outside the rounded one.
- *
- * See also: graphene_rect_round()
  *
  * Since: 1.10
  */

--- a/src/graphene-rect.c
+++ b/src/graphene-rect.c
@@ -758,9 +758,13 @@ graphene_rect_round_to_pixel (graphene_rect_t *r)
  * their nearest integer values; the rounding is guaranteed
  * to be large enough to have an area bigger or equal to the
  * original rectangle, but might not fully contain its extents.
+ * Use graphene_rect_round_extents() in case you need to round
+ * to a rectangle that covers fully the original one.
  *
  * This function is the equivalent of calling `floor` on
  * the coordinates of the origin, and `ceil` on the size.
+ *
+ * See also: graphene_rect_round_extents()
  *
  * Since: 1.4
  */
@@ -775,6 +779,56 @@ graphene_rect_round (const graphene_rect_t *r,
 
   res->size.width = ceilf (res->size.width);
   res->size.height = ceilf (res->size.height);
+}
+
+/**
+ * graphene_rect_round_extents:
+ * @r: a #graphene_rect_t
+ * @res: (out caller-allocates): return location for the
+ *   rectangle with rounded extents
+ *
+ * Rounds the origin of the given rectangle to its nearest
+ * integer value and and recompute the size so that the
+ * rectangle is large enough to contain all the conrners
+ * of the original rectangle.
+ *
+ * This function is the equivalent of calling `floor` on
+ * the coordinates of the origin, and recomputing the size
+ * calling `ceil` on the bottom-right coordinates.
+ *
+ * If you want to be sure that the rounded rectangle
+ * completely covers the area that was covered by the
+ * original rectangle — i.e. you want to cover the area
+ * including all its corners — this function will make sure
+ * that the size is recomputed taking into account the ceiling
+ * of the coordinates of the bottom-right corner.
+ * If the difference between the original coordinates and the
+ * coordinates of the rounded rectangle is greater than the
+ * difference between the original size and and the rounded
+ * size, then the move of the origin would not be compensated
+ * by a move in the anti-origin, leaving the corners of the
+ * original rectangle outside the rounded one.
+ *
+ * See also: graphene_rect_round()
+ *
+ * Since: 1.10
+ */
+void
+graphene_rect_round_extents (const graphene_rect_t *r,
+                             graphene_rect_t       *res)
+{
+  float x2, y2;
+
+  graphene_rect_normalize_r (r, res);
+
+  x2 = res->origin.x + res->size.width;
+  y2 = res->origin.y + res->size.height;
+
+  res->origin.x = floorf (res->origin.x);
+  res->origin.y = floorf (res->origin.y);
+
+  res->size.width = ceilf (x2) - res->origin.x;
+  res->size.height = ceilf (y2) - res->origin.y;
 }
 
 /**

--- a/src/graphene-rect.h
+++ b/src/graphene-rect.h
@@ -133,6 +133,8 @@ GRAPHENE_AVAILABLE_IN_1_0
 float                   graphene_rect_get_width         (const graphene_rect_t *r);
 GRAPHENE_AVAILABLE_IN_1_0
 float                   graphene_rect_get_height        (const graphene_rect_t *r);
+GRAPHENE_AVAILABLE_IN_1_10
+float                   graphene_rect_get_area          (const graphene_rect_t *r);
 
 GRAPHENE_AVAILABLE_IN_1_0
 void                    graphene_rect_union             (const graphene_rect_t *a,

--- a/src/graphene-rect.h
+++ b/src/graphene-rect.h
@@ -170,7 +170,7 @@ void                    graphene_rect_inset_r           (const graphene_rect_t  
                                                          graphene_rect_t        *res);
 GRAPHENE_DEPRECATED_IN_1_4_FOR (graphene_rect_round)
 graphene_rect_t *       graphene_rect_round_to_pixel    (graphene_rect_t        *r);
-GRAPHENE_AVAILABLE_IN_1_4
+GRAPHENE_DEPRECATED_IN_1_10_FOR (graphene_rect_round_extents)
 void                    graphene_rect_round             (const graphene_rect_t  *r,
                                                          graphene_rect_t        *res);
 GRAPHENE_AVAILABLE_IN_1_10

--- a/src/graphene-rect.h
+++ b/src/graphene-rect.h
@@ -173,6 +173,9 @@ graphene_rect_t *       graphene_rect_round_to_pixel    (graphene_rect_t        
 GRAPHENE_AVAILABLE_IN_1_4
 void                    graphene_rect_round             (const graphene_rect_t  *r,
                                                          graphene_rect_t        *res);
+GRAPHENE_AVAILABLE_IN_1_10
+void                    graphene_rect_round_extents     (const graphene_rect_t  *r,
+                                                         graphene_rect_t        *res);
 GRAPHENE_AVAILABLE_IN_1_0
 void                    graphene_rect_interpolate       (const graphene_rect_t  *a,
                                                          const graphene_rect_t  *b,

--- a/src/tests/rect.c
+++ b/src/tests/rect.c
@@ -185,6 +185,17 @@ GRAPHENE_TEST_UNIT_BEGIN (rect_inset)
 }
 GRAPHENE_TEST_UNIT_END
 
+GRAPHENE_TEST_UNIT_BEGIN (rect_area)
+{
+  graphene_rect_t r = GRAPHENE_RECT_INIT (0.5f, 1.9f,  9.3f, 8.7f);
+  graphene_rect_t n;
+
+  graphene_rect_normalize_r (&r, &n);
+
+  g_assert_cmpfloat (graphene_rect_get_area (&r), ==, n.size.width * n.size.height);
+}
+GRAPHENE_TEST_UNIT_END
+
 GRAPHENE_TEST_UNIT_BEGIN (rect_round)
 {
   graphene_rect_t r = GRAPHENE_RECT_INIT (0.5f, 1.9f,  9.3f, 8.7f);
@@ -192,11 +203,11 @@ GRAPHENE_TEST_UNIT_BEGIN (rect_round)
   graphene_rect_t rounded;
 
   graphene_rect_round (&r, &rounded);
-  g_assert_cmpfloat (rounded.size.width * rounded.size.height,
+  g_assert_cmpfloat (graphene_rect_get_area (&rounded),
                      >=,
-                     r.size.width * r.size.height);
+                     graphene_rect_get_area (&r));
   g_assert_false (graphene_rect_contains_rect (&rounded, &r));
-  g_assert_true (graphene_rect_equal (&rounded, &e));
+  graphene_assert_fuzzy_rect_equal (&rounded, &e, 0.01f);
 }
 GRAPHENE_TEST_UNIT_END
 
@@ -316,6 +327,7 @@ GRAPHENE_TEST_SUITE (
   GRAPHENE_TEST_UNIT ("/rect/union", rect_union)
   GRAPHENE_TEST_UNIT ("/rect/offset", rect_offset)
   GRAPHENE_TEST_UNIT ("/rect/inset", rect_inset)
+  GRAPHENE_TEST_UNIT ("/rect/area", rect_area)
   GRAPHENE_TEST_UNIT ("/rect/round", rect_round)
   GRAPHENE_TEST_UNIT ("/rect/round-to-pixel", rect_round_to_pixel)
   GRAPHENE_TEST_UNIT ("/rect/expand", rect_expand)

--- a/src/tests/rect.c
+++ b/src/tests/rect.c
@@ -185,6 +185,20 @@ GRAPHENE_TEST_UNIT_BEGIN (rect_inset)
 }
 GRAPHENE_TEST_UNIT_END
 
+GRAPHENE_TEST_UNIT_BEGIN (rect_round)
+{
+  graphene_rect_t r = GRAPHENE_RECT_INIT (0.5f, 1.9f,  9.3f, 8.7f);
+  graphene_rect_t e = GRAPHENE_RECT_INIT (0.0f, 1.0f, 10.0f, 9.0f);
+  graphene_rect_t rounded;
+
+  graphene_rect_round (&r, &rounded);
+  g_assert_cmpfloat (rounded.size.width * rounded.size.height,
+                     >=,
+                     r.size.width * r.size.height);
+  g_assert_true (graphene_rect_equal (&rounded, &e));
+}
+GRAPHENE_TEST_UNIT_END
+
 GRAPHENE_TEST_UNIT_BEGIN (rect_round_to_pixel)
 {
   graphene_rect_t r = GRAPHENE_RECT_INIT (0.5f, 1.9f,  9.3f, 8.7f);
@@ -301,6 +315,7 @@ GRAPHENE_TEST_SUITE (
   GRAPHENE_TEST_UNIT ("/rect/union", rect_union)
   GRAPHENE_TEST_UNIT ("/rect/offset", rect_offset)
   GRAPHENE_TEST_UNIT ("/rect/inset", rect_inset)
+  GRAPHENE_TEST_UNIT ("/rect/round", rect_round)
   GRAPHENE_TEST_UNIT ("/rect/round-to-pixel", rect_round_to_pixel)
   GRAPHENE_TEST_UNIT ("/rect/expand", rect_expand)
   GRAPHENE_TEST_UNIT ("/rect/interpolate", rect_interpolate)

--- a/src/tests/rect.c
+++ b/src/tests/rect.c
@@ -195,6 +195,7 @@ GRAPHENE_TEST_UNIT_BEGIN (rect_round)
   g_assert_cmpfloat (rounded.size.width * rounded.size.height,
                      >=,
                      r.size.width * r.size.height);
+  g_assert_false (graphene_rect_contains_rect (&rounded, &r));
   g_assert_true (graphene_rect_equal (&rounded, &e));
 }
 GRAPHENE_TEST_UNIT_END

--- a/src/tests/rect.c
+++ b/src/tests/rect.c
@@ -222,6 +222,32 @@ GRAPHENE_TEST_UNIT_BEGIN (rect_round_to_pixel)
 }
 GRAPHENE_TEST_UNIT_END
 
+GRAPHENE_TEST_UNIT_BEGIN (rect_round_extents)
+{
+  graphene_rect_t r = GRAPHENE_RECT_INIT (2.5f, 1.9f,  9.3f, 8.7f);
+  graphene_rect_t s = GRAPHENE_RECT_INIT (2.0f, 1.0f, 10.0f, 10.0f);
+  graphene_rect_t rounded;
+  graphene_point_t p;
+
+  graphene_rect_round_extents (&r, &rounded);
+
+  graphene_rect_get_top_left (&r, &p);
+  g_assert_true (graphene_rect_contains_point (&rounded, &p));
+
+  graphene_rect_get_top_right (&r, &p);
+  g_assert_true (graphene_rect_contains_point (&rounded, &p));
+
+  graphene_rect_get_bottom_left (&r, &p);
+  g_assert_true (graphene_rect_contains_point (&rounded, &p));
+
+  graphene_rect_get_bottom_right (&r, &p);
+  g_assert_true (graphene_rect_contains_point (&rounded, &p));
+
+  g_assert_true (graphene_rect_contains_rect (&rounded, &r));
+  g_assert_true (graphene_rect_equal (&rounded, &s));
+}
+GRAPHENE_TEST_UNIT_END
+
 GRAPHENE_TEST_UNIT_BEGIN (rect_expand)
 {
   graphene_rect_t r = GRAPHENE_RECT_INIT (0.f, 0.f, 100.f, 100.f);
@@ -330,6 +356,7 @@ GRAPHENE_TEST_SUITE (
   GRAPHENE_TEST_UNIT ("/rect/area", rect_area)
   GRAPHENE_TEST_UNIT ("/rect/round", rect_round)
   GRAPHENE_TEST_UNIT ("/rect/round-to-pixel", rect_round_to_pixel)
+  GRAPHENE_TEST_UNIT ("/rect/round-extents", rect_round_extents)
   GRAPHENE_TEST_UNIT ("/rect/expand", rect_expand)
   GRAPHENE_TEST_UNIT ("/rect/interpolate", rect_interpolate)
   GRAPHENE_TEST_UNIT ("/rect/scale", rect_scale)


### PR DESCRIPTION
Proposed changes:

 - Add function for computing the area of a rect
 - Add function to compute the rounded extents
 - Fix docstring for round function
 - Add function to print rects

Test suite changes:
 - Test for `graphene_rect_round`
 - Test for `graphene_rect_get_area`
 - Test for `graphene_rect_round_extents`

Not sure if changing the round function would have been better, but I'd say no, as these two roundings cover different cases (for example, we'd need to round the extents when we want to pass a fractional rect for damaging the area).