### PR TITLE
Add equality operators for the matrix type

### DIFF
--- a/doc/graphene-sections.txt
+++ b/doc/graphene-sections.txt
@@ -172,6 +172,9 @@ graphene_matrix_get_x_scale
 graphene_matrix_get_y_scale
 graphene_matrix_get_z_scale
 graphene_matrix_interpolate
+graphene_matrix_equal
+graphene_matrix_equal_fast
+graphene_matrix_near
 graphene_matrix_print
 </SECTION>
 

--- a/src/graphene-matrix.c
+++ b/src/graphene-matrix.c
@@ -2158,3 +2158,100 @@ graphene_matrix_print (const graphene_matrix_t *m)
                graphene_matrix_get_value (m, i, 3));
     }
 }
+
+/**
+ * graphene_matrix_near:
+ * @a: a #graphene_matrix_t
+ * @b: a #graphene_matrix_t
+ *
+ * Compares the two given #graphene_matrix_t matrices and check
+ * whether their values are within the given @epsilon of each
+ * other.
+ *
+ * Returns: `true` if the two matrices are near each other, and
+ *   `false` otherwise
+ *
+ * Since: 1.10
+ */
+bool
+graphene_matrix_near (const graphene_matrix_t *a,
+                      const graphene_matrix_t *b,
+                      float                    epsilon)
+{
+  if (a == b)
+    return true;
+
+  if (a == NULL || b == NULL)
+    return false;
+
+  for (unsigned i = 0; i < 4; i++)
+    {
+      graphene_vec4_t row_a, row_b;
+
+      graphene_matrix_get_row (a, i, &row_a);
+      graphene_matrix_get_row (b, i, &row_b);
+
+      if (!graphene_vec4_near (&row_a, &row_b, epsilon))
+        return false;
+    }
+
+  return true;
+}
+
+/**
+ * graphene_matrix_equal:
+ * @a: a #graphene_matrix_t
+ * @b: a #graphene_matrix_t
+ *
+ * Checks whether the two given #graphene_matrix_t matrices are equal.
+ *
+ * Returns: `true` if the two matrices are equal, and `false` otherwise
+ *
+ * Since: 1.10
+ */
+bool
+graphene_matrix_equal (const graphene_matrix_t *a,
+                       const graphene_matrix_t *b)
+{
+  return graphene_matrix_near (a, b, FLT_EPSILON);
+}
+
+/**
+ * graphene_matrix_equal_fast:
+ * @a: a #graphene_matrix_t
+ * @b: a #graphene_matrix_t
+ *
+ * Checks whether the two given #graphene_matrix_t matrices are
+ * byte-by-byte equal.
+ *
+ * While this function is faster than graphene_matrix_equal(), it
+ * can also return false negatives, so it should be used in
+ * conjuction with either graphene_matrix_equal() or
+ * graphene_matrix_near(). For instance:
+ *
+ * |[<!-- language="C" -->
+ *   if (graphene_matrix_equal_fast (a, b))
+ *     {
+ *       // matrices are definitely the same
+ *     }
+ *   else
+ *     {
+ *       if (graphene_matrix_equal (a, b))
+ *         // matrices contain the same values within an epsilon of FLT_EPSILON
+ *       else if (graphene_matrix_near (a, b, 0.0001))
+ *         // matrices contain the same values within an epsilon of 0.0001
+ *       else
+ *         // matrices are not equal
+ *     }
+ * ]|
+ *
+ * Returns: `true` if the matrices are equal. and `false` otherwise
+ *
+ * Since: 1.10
+ */
+bool
+graphene_matrix_equal_fast (const graphene_matrix_t *a,
+                            const graphene_matrix_t *b)
+{
+  return memcmp (a, b, sizeof (graphene_matrix_t)) == 0;
+}

--- a/src/graphene-matrix.h
+++ b/src/graphene-matrix.h
@@ -280,6 +280,17 @@ void                    graphene_matrix_interpolate             (const graphene_
                                                                  double                    factor,
                                                                  graphene_matrix_t        *res);
 
+GRAPHENE_AVAILABLE_IN_1_10
+bool                    graphene_matrix_near                    (const graphene_matrix_t  *a,
+                                                                 const graphene_matrix_t  *b,
+                                                                 float                     epsilon);
+GRAPHENE_AVAILABLE_IN_1_10
+bool                    graphene_matrix_equal                   (const graphene_matrix_t  *a,
+                                                                 const graphene_matrix_t  *b);
+GRAPHENE_AVAILABLE_IN_1_10
+bool                    graphene_matrix_equal_fast              (const graphene_matrix_t  *a,
+                                                                 const graphene_matrix_t  *b);
+
 GRAPHENE_AVAILABLE_IN_1_0
 void                    graphene_matrix_print                   (const graphene_matrix_t  *m);
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -73,7 +73,6 @@ graphene_config_h = configure_file(
   input: 'graphene-config.h.meson',
   output: 'graphene-config.h',
   configuration: graphene_conf,
-  install: true,
   install_dir: join_paths(graphene_libdir, graphene_api_path, 'include'),
 )
 
@@ -88,7 +87,6 @@ configure_file(
   input: 'graphene-version.h.in',
   output: 'graphene-version.h',
   configuration: version_conf,
-  install: true,
   install_dir: join_paths(graphene_includedir, graphene_api_path),
 )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -134,7 +134,6 @@ foreach p: pkgconfig_files
     name: 'Graphene',
     description: 'Math classes for graphic libraries',
     url: 'https://ebassi.github.io/graphene',
-    version: meson.project_version(),
     filebase: pkg_name,
     variables: [
       'graphene_has_sse2=@0@'.format(has_sse2),

--- a/src/tests/matrix.c
+++ b/src/tests/matrix.c
@@ -45,6 +45,27 @@ GRAPHENE_TEST_UNIT_BEGIN (matrix_identity)
 }
 GRAPHENE_TEST_UNIT_END
 
+GRAPHENE_TEST_UNIT_BEGIN (matrix_equal)
+{
+  graphene_matrix_t m1, m2;
+
+  graphene_matrix_init_identity (&m1);
+  graphene_matrix_init_identity (&m2);
+
+  g_assert_true (graphene_matrix_equal (&m1, &m1));
+  g_assert_false (graphene_matrix_equal (&m1, NULL));
+  g_assert_false (graphene_matrix_equal (NULL, &m1));
+
+  g_assert_true (graphene_matrix_equal_fast (&m1, &m2));
+  g_assert_true (graphene_matrix_equal (&m1, &m2));
+
+  graphene_matrix_scale (&m1, 0.002f, 0.002f, 0.002f);
+  graphene_matrix_scale (&m2, 0.001f, 0.001f, 0.001f);
+  g_assert_false (graphene_matrix_equal (&m1, &m2));
+  g_assert_true (graphene_matrix_near (&m1, &m2, 0.01f));
+}
+GRAPHENE_TEST_UNIT_END
+
 GRAPHENE_TEST_UNIT_BEGIN (matrix_rotation)
 {
   graphene_matrix_t m;
@@ -598,6 +619,7 @@ GRAPHENE_TEST_UNIT_END
 
 GRAPHENE_TEST_SUITE (
   GRAPHENE_TEST_UNIT ("/matrix/identity", matrix_identity)
+  GRAPHENE_TEST_UNIT ("/matrix/equal", matrix_equal)
   GRAPHENE_TEST_UNIT ("/matrix/scale", matrix_scale)
   GRAPHENE_TEST_UNIT ("/matrix/rotation", matrix_rotation)
   GRAPHENE_TEST_UNIT ("/matrix/rotation/euler-quaternion", matrix_rotation_euler_quaternion)


### PR DESCRIPTION
Proposed changes:

 - add a `graphene_matrix_near()` function
 - use `near()` to implement `graphene_matrix_equal()`
 - add a byte-by-byte comparator for fast checks
 - document all newly added API

Test suite changes:

 - add a unit for the newly added API
