### PR TITLE
rect: Add GRAPHENE_RECT_INIT_ZERO

### DIFF
--- a/src/graphene-rect.h
+++ b/src/graphene-rect.h
@@ -50,6 +50,16 @@ GRAPHENE_BEGIN_DECLS
   (graphene_rect_t) { .origin = { .x = (_x), .y = (_y) }, .size = { .width = (_w), .height = (_h) } }
 
 /**
+ * GRAPHENE_RECT_INIT_ZERO:
+ *
+ * Initializes a #graphene_rect_t to a degenerate rectangle with an origin
+ * in (0, 0) and a size of 0.
+ *
+ * Since: 1.10
+ */
+#define GRAPHENE_RECT_INIT_ZERO         GRAPHENE_RECT_INIT (0.f, 0.f, 0.f, 0.f)
+
+/**
  * graphene_rect_t:
  * @origin: the coordinates of the origin of the rectangle
  * @size: the size of the rectangle

--- a/src/tests/rect.c
+++ b/src/tests/rect.c
@@ -5,6 +5,7 @@
 
 GRAPHENE_TEST_UNIT_BEGIN (rect_init)
 {
+  graphene_rect_t zero;
   graphene_rect_t *r;
   graphene_rect_t r2;
 
@@ -16,6 +17,9 @@ GRAPHENE_TEST_UNIT_BEGIN (rect_init)
 
   graphene_rect_init_from_rect (&r2, r);
   g_assert_true (graphene_rect_equal (&r2, r));
+
+  zero = GRAPHENE_RECT_INIT_ZERO;
+  graphene_assert_fuzzy_rect_equal (&zero, graphene_rect_zero (), 0.0001f);
 
   graphene_rect_free (r);
 }

--- a/src/tests/rect.c
+++ b/src/tests/rect.c
@@ -6,7 +6,7 @@
 GRAPHENE_TEST_UNIT_BEGIN (rect_init)
 {
   graphene_rect_t *r;
-  graphene_rect_t s;
+  graphene_rect_t r2;
 
   r = graphene_rect_init (graphene_rect_alloc (), 0.f, 0.f, 10.f, 10.f);
   g_assert_cmpfloat (r->origin.x, ==, 0.f);
@@ -14,8 +14,8 @@ GRAPHENE_TEST_UNIT_BEGIN (rect_init)
   g_assert_cmpfloat (r->size.width, ==, 10.f);
   g_assert_cmpfloat (r->size.height, ==, 10.f);
 
-  graphene_rect_init_from_rect (&s, r);
-  g_assert_true (graphene_rect_equal (&s, r));
+  graphene_rect_init_from_rect (&r2, r);
+  g_assert_true (graphene_rect_equal (&r2, r));
 
   graphene_rect_free (r);
 }


### PR DESCRIPTION
All other similar types have this initializer, and it
is quite handy.

Proposed changes:

 - Add `GRAPHENE_RECT_INIT_ZERO`

Benchmark results: 

*(Does not apply)*

Test suite changes:

 - Add an extra check in `rect_init` test
