### PR TITLE
Add a test that roundtrips eulers via a matrix

### DIFF
--- a/src/tests/euler.c
+++ b/src/tests/euler.c
@@ -44,7 +44,32 @@ GRAPHENE_TEST_UNIT_BEGIN (euler_quaternion_roundtrip)
 }
 GRAPHENE_TEST_UNIT_END
 
+GRAPHENE_TEST_UNIT_BEGIN (euler_matrix_roundtrip)
+{
+  graphene_euler_t values[3];
+  unsigned int i;
+
+  graphene_euler_init_with_order (&values[0], 0.f, 0.f, 0.f, GRAPHENE_EULER_ORDER_XYZ);
+  graphene_euler_init_with_order (&values[1], 1.f, 0.f, 0.f, GRAPHENE_EULER_ORDER_XYZ);
+  graphene_euler_init_with_order (&values[2], 0.f, 1.f, 0.f, GRAPHENE_EULER_ORDER_ZYX);
+
+  for (i = 0; i < G_N_ELEMENTS (values); i++)
+    {
+      graphene_matrix_t m, check;
+      graphene_euler_t e;
+
+      graphene_euler_to_matrix (&values[i], &m);
+      graphene_euler_init_from_matrix (&e, &m, graphene_euler_get_order (&values[i]));
+
+      graphene_euler_to_matrix (&e, &check);
+
+      graphene_assert_fuzzy_matrix_equal (&m, &check, 0.01);
+    }
+}
+GRAPHENE_TEST_UNIT_END
+
 GRAPHENE_TEST_SUITE (
   GRAPHENE_TEST_UNIT ("/euler/init", euler_init)
   GRAPHENE_TEST_UNIT ("/euler/quaternion-roundtrip", euler_quaternion_roundtrip)
+  GRAPHENE_TEST_UNIT ("/euler/matrix-roundtrip", euler_matrix_roundtrip)
 )


### PR DESCRIPTION
This is currently failing, it seems like there is some kind of sign
issue in the matrix conversion.

I noted this in gthree, where its breaking the look_at function. 
