### PR TITLE
Reimplement Euler angles

### DIFF
--- a/.appveyor/msvc.bat
+++ b/.appveyor/msvc.bat
@@ -4,12 +4,12 @@
 mkdir _build
 mkdir graphene-shared-%MSVC_PLATFORM%
 cd _build
-curl -LsSO https://github.com/mesonbuild/meson/releases/download/0.49.0/meson-0.49.0.tar.gz
-7z x meson-0.49.0.tar.gz
-move dist\meson-0.49.0.tar .
-7z x meson-0.49.0.tar
+curl -LsSO https://github.com/mesonbuild/meson/releases/download/0.50.1/meson-0.50.1.tar.gz
+7z x meson-0.50.1.tar.gz
+move dist\meson-0.50.1.tar .
+7z x meson-0.50.1.tar
 rmdir dist
-del meson-0.49.0.tar meson-0.49.0.tar.gz
+del meson-0.50.1.tar meson-0.50.1.tar.gz
 curl -LsSO https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip
 7z x ninja-win.zip
 del ninja-win.zip
@@ -19,7 +19,7 @@ cd ..
 cd _build
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %MSVC_PLATFORM%
 @echo on
-C:\Python36\python.exe meson-0.49.0\meson.py .. . --backend=ninja --prefix=%APPVEYOR_BUILD_FOLDER%\graphene-shared-%MSVC_PLATFORM% || goto :error
+C:\Python36\python.exe meson-0.50.1\meson.py .. . --backend=ninja --prefix=%APPVEYOR_BUILD_FOLDER%\graphene-shared-%MSVC_PLATFORM% || goto :error
 ninja || goto :error
 ninja test || goto :error
 ninja install || goto :error

--- a/doc/graphene-sections.txt
+++ b/doc/graphene-sections.txt
@@ -51,6 +51,9 @@ graphene_euler_get_x
 graphene_euler_get_y
 graphene_euler_get_z
 graphene_euler_get_order
+graphene_euler_get_alpha
+graphene_euler_get_beta
+graphene_euler_get_gamma
 graphene_euler_to_vec3
 graphene_euler_to_matrix
 graphene_euler_reorder

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('graphene', 'c',
         version: '1.9.3',
         license: 'MIT',
-        meson_version: '>= 0.48.0',
+        meson_version: '>= 0.50.1',
         default_options: [
           'buildtype=debugoptimized',
           'c_std=c99',

--- a/src/graphene-euler.c
+++ b/src/graphene-euler.c
@@ -98,7 +98,7 @@
 #include "graphene-quaternion.h"
 #include "graphene-vectors-private.h"
 
-#define EULER_DEFAULT_ORDER GRAPHENE_EULER_ORDER_XYZ
+#define EULER_DEFAULT_ORDER GRAPHENE_EULER_ORDER_SXYZ
 
 #define LAST_DEPRECATED GRAPHENE_EULER_ORDER_ZYX + 1
 
@@ -382,6 +382,39 @@ graphene_euler_free (graphene_euler_t *e)
   graphene_aligned_free (e);
 }
 
+static graphene_euler_order_t
+graphene_euler_get_real_order (graphene_euler_order_t order)
+{
+  switch (order)
+    {
+    case GRAPHENE_EULER_ORDER_XYZ:
+      return GRAPHENE_EULER_ORDER_SXYZ;
+
+    case GRAPHENE_EULER_ORDER_YXZ:
+      return GRAPHENE_EULER_ORDER_SYXZ;
+
+    case GRAPHENE_EULER_ORDER_ZXY:
+      return GRAPHENE_EULER_ORDER_SZXY;
+
+    case GRAPHENE_EULER_ORDER_ZYX:
+      return GRAPHENE_EULER_ORDER_SZYX;
+
+    case GRAPHENE_EULER_ORDER_YZX:
+      return GRAPHENE_EULER_ORDER_SYZX;
+
+    case GRAPHENE_EULER_ORDER_XZY:
+      return GRAPHENE_EULER_ORDER_SXZY;
+
+    case GRAPHENE_EULER_ORDER_DEFAULT:
+      return GRAPHENE_EULER_ORDER_SXYZ;
+
+    default:
+      break;
+    }
+
+  return order;
+}
+
 /*< private >
  * graphene_euler_init_internal:
  * @e: the #graphene_euler_t to initialize
@@ -403,7 +436,7 @@ graphene_euler_init_internal (graphene_euler_t       *e,
                               graphene_euler_order_t  order)
 {
   graphene_vec3_init (&e->angles, rad_x, rad_y, rad_z);
-  e->order = order;
+  e->order = graphene_euler_get_real_order (order);
 
   return e;
 }
@@ -753,45 +786,10 @@ graphene_euler_to_vec3 (const graphene_euler_t *e,
   graphene_vec3_scale (res, (180.f / GRAPHENE_PI), res);
 }
 
-static graphene_euler_order_t
-graphene_euler_get_real_order (const graphene_euler_t *e)
-{
-  graphene_euler_order_t order = graphene_euler_get_order (e);
-
-  switch (order)
-    {
-    case GRAPHENE_EULER_ORDER_XYZ:
-      return GRAPHENE_EULER_ORDER_SXYZ;
-
-    case GRAPHENE_EULER_ORDER_YXZ:
-      return GRAPHENE_EULER_ORDER_SYXZ;
-
-    case GRAPHENE_EULER_ORDER_ZXY:
-      return GRAPHENE_EULER_ORDER_SZXY;
-
-    case GRAPHENE_EULER_ORDER_ZYX:
-      return GRAPHENE_EULER_ORDER_SZYX;
-
-    case GRAPHENE_EULER_ORDER_YZX:
-      return GRAPHENE_EULER_ORDER_SYZX;
-
-    case GRAPHENE_EULER_ORDER_XZY:
-      return GRAPHENE_EULER_ORDER_SXZY;
-
-    case GRAPHENE_EULER_ORDER_DEFAULT:
-      return GRAPHENE_EULER_ORDER_SXYZ;
-
-    default:
-      break;
-    }
-
-  return order;
-}
-
 static float
 graphene_euler_get_alpha (const graphene_euler_t *e)
 {
-  graphene_euler_order_t order = graphene_euler_get_real_order (e);
+  graphene_euler_order_t order = graphene_euler_get_real_order (e->order);
 
   switch (order)
     {
@@ -835,7 +833,7 @@ graphene_euler_get_alpha (const graphene_euler_t *e)
 static float
 graphene_euler_get_beta (const graphene_euler_t *e)
 {
-  graphene_euler_order_t order = graphene_euler_get_real_order (e);
+  graphene_euler_order_t order = graphene_euler_get_real_order (e->order);
 
   switch (order)
     {
@@ -879,7 +877,7 @@ graphene_euler_get_beta (const graphene_euler_t *e)
 static float
 graphene_euler_get_gamma (const graphene_euler_t *e)
 {
-  graphene_euler_order_t order = graphene_euler_get_real_order (e);
+  graphene_euler_order_t order = graphene_euler_get_real_order (e->order);
 
   switch (order)
     {
@@ -948,7 +946,7 @@ void
 graphene_euler_to_matrix (const graphene_euler_t *e,
                           graphene_matrix_t      *res)
 {
-  graphene_euler_order_t order = graphene_euler_get_real_order (e);
+  graphene_euler_order_t order = graphene_euler_get_real_order (e->order);
   float ai = graphene_euler_get_alpha (e);
   float aj = graphene_euler_get_beta (e);
   float ak = graphene_euler_get_gamma (e);
@@ -982,7 +980,7 @@ graphene_euler_to_quaternion (const graphene_euler_t *e,
   float sc = si * ck;
   float ss = si * sk;
 
-  graphene_euler_order_t order = graphene_euler_get_real_order (e);
+  graphene_euler_order_t order = graphene_euler_get_real_order (e->order);
   const struct axis_param *params = &order_parameters[ORDER_OFFSET (order)];
 
   if (params->repetition)

--- a/src/graphene-euler.c
+++ b/src/graphene-euler.c
@@ -911,6 +911,8 @@ graphene_euler_to_matrix (const graphene_euler_t *e,
  * @res: (out caller-allocates): return location for a #graphene_quaternion_t
  *
  * Converts a #graphene_euler_t into a #graphene_quaternion_t.
+ *
+ * Since: 1.10
  */
 void
 graphene_euler_to_quaternion (const graphene_euler_t *e,

--- a/src/graphene-euler.c
+++ b/src/graphene-euler.c
@@ -737,7 +737,20 @@ graphene_euler_to_vec3 (const graphene_euler_t *e,
   graphene_vec3_scale (res, (180.f / GRAPHENE_PI), res);
 }
 
-static float
+/**
+ * graphene_euler_get_alpha:
+ * @e: a #graphene_euler_t
+ *
+ * Retrieves the first component of the Euler angle vector,
+ * depending on the order of rotation.
+ *
+ * See also: graphene_euler_get_x()
+ *
+ * Returns: the first component of the Euler angle vector, in radians
+ *
+ * Since: 1.10
+ */
+float
 graphene_euler_get_alpha (const graphene_euler_t *e)
 {
   graphene_euler_order_t order = graphene_euler_get_real_order (e->order);
@@ -781,7 +794,20 @@ graphene_euler_get_alpha (const graphene_euler_t *e)
   return 0.f;
 }
 
-static float
+/**
+ * graphene_euler_get_beta:
+ * @e: a #graphene_euler_t
+ *
+ * Retrieves the second component of the Euler angle vector,
+ * depending on the order of rotation.
+ *
+ * See also: graphene_euler_get_y()
+ *
+ * Returns: the second component of the Euler angle vector, in radians
+ *
+ * Since: 1.10
+ */
+float
 graphene_euler_get_beta (const graphene_euler_t *e)
 {
   graphene_euler_order_t order = graphene_euler_get_real_order (e->order);
@@ -825,7 +851,20 @@ graphene_euler_get_beta (const graphene_euler_t *e)
   return 0.f;
 }
 
-static float
+/**
+ * graphene_euler_get_gamma:
+ * @e: a #graphene_euler_t
+ *
+ * Retrieves the third component of the Euler angle vector,
+ * depending on the order of rotation.
+ *
+ * See also: graphene_euler_get_z()
+ *
+ * Returns: the third component of the Euler angle vector, in radians
+ *
+ * Since: 1.10
+ */
+float
 graphene_euler_get_gamma (const graphene_euler_t *e)
 {
   graphene_euler_order_t order = graphene_euler_get_real_order (e->order);

--- a/src/graphene-euler.c
+++ b/src/graphene-euler.c
@@ -943,7 +943,7 @@ graphene_euler_get_gamma (const graphene_euler_t *e)
  *  * the third rotation moves the body around the Z axis with
  *    an angle of ψ
  *
- * The rotation sign convention is left-handed, to preserve compatibility
+ * The rotation sign convention is right-handed, to preserve compatibility
  * between Euler-based, quaternion-based, and angle-axis-based rotations.
  *
  * Since: 1.2

--- a/src/graphene-euler.h
+++ b/src/graphene-euler.h
@@ -53,12 +53,42 @@ GRAPHENE_BEGIN_DECLS
  */
 typedef enum {
   GRAPHENE_EULER_ORDER_DEFAULT = -1,
+
+  /* Deprecated */
   GRAPHENE_EULER_ORDER_XYZ = 0,
   GRAPHENE_EULER_ORDER_YZX,
   GRAPHENE_EULER_ORDER_ZXY,
   GRAPHENE_EULER_ORDER_XZY,
   GRAPHENE_EULER_ORDER_YXZ,
-  GRAPHENE_EULER_ORDER_ZYX
+  GRAPHENE_EULER_ORDER_ZYX,
+
+  /* Static (extrinsic) coordinate axes */
+  GRAPHENE_EULER_ORDER_SXYZ,
+  GRAPHENE_EULER_ORDER_SXYX,
+  GRAPHENE_EULER_ORDER_SXZY,
+  GRAPHENE_EULER_ORDER_SXZX,
+  GRAPHENE_EULER_ORDER_SYZX,
+  GRAPHENE_EULER_ORDER_SYZY,
+  GRAPHENE_EULER_ORDER_SYXZ,
+  GRAPHENE_EULER_ORDER_SYXY,
+  GRAPHENE_EULER_ORDER_SZXY,
+  GRAPHENE_EULER_ORDER_SZXZ,
+  GRAPHENE_EULER_ORDER_SZYX,
+  GRAPHENE_EULER_ORDER_SZYZ,
+
+  /* Relative (intrinsic) coordinate axes */
+  GRAPHENE_EULER_ORDER_RZYX,
+  GRAPHENE_EULER_ORDER_RXYX,
+  GRAPHENE_EULER_ORDER_RYZX,
+  GRAPHENE_EULER_ORDER_RXZX,
+  GRAPHENE_EULER_ORDER_RXZY,
+  GRAPHENE_EULER_ORDER_RYZY,
+  GRAPHENE_EULER_ORDER_RZXY,
+  GRAPHENE_EULER_ORDER_RYXY,
+  GRAPHENE_EULER_ORDER_RYXZ,
+  GRAPHENE_EULER_ORDER_RZXZ,
+  GRAPHENE_EULER_ORDER_RXYZ,
+  GRAPHENE_EULER_ORDER_RZYZ
 } graphene_euler_order_t;
 
 /**
@@ -129,6 +159,9 @@ void                    graphene_euler_to_vec3                  (const graphene_
 GRAPHENE_AVAILABLE_IN_1_2
 void                    graphene_euler_to_matrix                (const graphene_euler_t      *e,
                                                                  graphene_matrix_t           *res);
+GRAPHENE_AVAILABLE_IN_1_10
+void                    graphene_euler_to_quaternion            (const graphene_euler_t      *e,
+                                                                 graphene_quaternion_t       *res);
 
 GRAPHENE_AVAILABLE_IN_1_2
 void                    graphene_euler_reorder                  (const graphene_euler_t      *e,

--- a/src/graphene-euler.h
+++ b/src/graphene-euler.h
@@ -183,6 +183,13 @@ float                   graphene_euler_get_z                    (const graphene_
 GRAPHENE_AVAILABLE_IN_1_2
 graphene_euler_order_t  graphene_euler_get_order                (const graphene_euler_t      *e);
 
+GRAPHENE_AVAILABLE_IN_1_10
+float                   graphene_euler_get_alpha                (const graphene_euler_t      *e);
+GRAPHENE_AVAILABLE_IN_1_10
+float                   graphene_euler_get_beta                 (const graphene_euler_t      *e);
+GRAPHENE_AVAILABLE_IN_1_10
+float                   graphene_euler_get_gamma                (const graphene_euler_t      *e);
+
 GRAPHENE_AVAILABLE_IN_1_2
 void                    graphene_euler_to_vec3                  (const graphene_euler_t      *e,
                                                                  graphene_vec3_t             *res);

--- a/src/graphene-euler.h
+++ b/src/graphene-euler.h
@@ -37,12 +37,42 @@ GRAPHENE_BEGIN_DECLS
  * graphene_euler_order_t:
  * @GRAPHENE_EULER_ORDER_DEFAULT: Rotate in the default order; the
  *   default order is one of the following enumeration values
- * @GRAPHENE_EULER_ORDER_XYZ: Rotate in the X, Y, and Z order
- * @GRAPHENE_EULER_ORDER_YZX: Rotate in the Y, Z, and X order
- * @GRAPHENE_EULER_ORDER_ZXY: Rotate in the Z, X, and Y order
- * @GRAPHENE_EULER_ORDER_XZY: Rotate in the X, Z, and Y order
- * @GRAPHENE_EULER_ORDER_YXZ: Rotate in the Y, X, and Z order
- * @GRAPHENE_EULER_ORDER_ZYX: Rotate in the Z, Y, and X order
+ * @GRAPHENE_EULER_ORDER_XYZ: Rotate in the X, Y, and Z order. Deprecated in
+ *   Graphene 1.10, it's an alias for %GRAPHENE_EULER_ORDER_SXYZ
+ * @GRAPHENE_EULER_ORDER_YZX: Rotate in the Y, Z, and X order. Deprecated in
+ *   Graphene 1.10, it's an alias for %GRAPHENE_EULER_ORDER_SYZX
+ * @GRAPHENE_EULER_ORDER_ZXY: Rotate in the Z, X, and Y order. Deprecated in
+ *   Graphene 1.10, it's an alias for %GRAPHENE_EULER_ORDER_SZXY
+ * @GRAPHENE_EULER_ORDER_XZY: Rotate in the X, Z, and Y order. Deprecated in
+ *   Graphene 1.10, it's an alias for %GRAPHENE_EULER_ORDER_SXZY
+ * @GRAPHENE_EULER_ORDER_YXZ: Rotate in the Y, X, and Z order. Deprecated in
+ *   Graphene 1.10, it's an alias for %GRAPHENE_EULER_ORDER_SYXZ
+ * @GRAPHENE_EULER_ORDER_ZYX: Rotate in the Z, Y, and X order. Deprecated in
+ *   Graphene 1.10, it's an alias for %GRAPHENE_EULER_ORDER_SZYX
+ * @GRAPHENE_EULER_ORDER_SXYZ: Defines a static rotation along the X, Y, and Z axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_SXYX: Defines a static rotation along the X, Y, and X axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_SXZY: Defines a static rotation along the X, Z, and Y axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_SXZX: Defines a static rotation along the X, Z, and X axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_SYZX: Defines a static rotation along the Y, Z, and X axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_SYZY: Defines a static rotation along the Y, Z, and Y axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_SYXZ: Defines a static rotation along the Y, X, and Z axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_SYXY: Defines a static rotation along the Y, X, and Y axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_SZXY: Defines a static rotation along the Z, X, and Y axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_SZXZ: Defines a static rotation along the Z, X, and Z axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_SZYX: Defines a static rotation along the Z, Y, and X axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_SZYZ: Defines a static rotation along the Z, Y, and Z axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_RZYX: Defines a relative rotation along the Z, Y, and X axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_RXYX: Defines a relative rotation along the X, Y, and X axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_RYZX: Defines a relative rotation along the Y, Z, and X axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_RXZX: Defines a relative rotation along the X, Z, and X axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_RXZY: Defines a relative rotation along the X, Z, and Y axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_RYZY: Defines a relative rotation along the Y, Z, and Y axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_RZXY: Defines a relative rotation along the Z, X, and Y axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_RYXY: Defines a relative rotation along the Y, X, and Y axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_RYXZ: Defines a relative rotation along the Y, X, and Z axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_RZXZ: Defines a relative rotation along the Z, X, and Z axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_RXYZ: Defines a relative rotation along the X, Y, and Z axes (Since: 1.10)
+ * @GRAPHENE_EULER_ORDER_RZYZ: Defines a relative rotation along the Z, Y, and Z axes (Since: 1.10)
  *
  * Specify the order of the rotations on each axis.
  *

--- a/src/graphene-quaternion.c
+++ b/src/graphene-quaternion.c
@@ -537,78 +537,7 @@ graphene_quaternion_t *
 graphene_quaternion_init_from_euler (graphene_quaternion_t  *q,
                                      const graphene_euler_t *e)
 {
-  graphene_euler_order_t order = graphene_euler_get_order (e);
-  const float ex = GRAPHENE_DEG_TO_RAD (graphene_euler_get_x (e)) / 2.f;
-  const float ey = GRAPHENE_DEG_TO_RAD (graphene_euler_get_y (e)) / 2.f;
-  const float ez = GRAPHENE_DEG_TO_RAD (graphene_euler_get_z (e)) / 2.f;
-  float c1, c2, c3, s1, s2, s3;
-  float s1c2c3, c1s2s3, c1s2c3, s1c2s3;
-  float c1c2s3, s1s2c3, c1c2c3, s1s2s3;
-
-  graphene_sincos (ex, &s1, &c1);
-  graphene_sincos (ey, &s2, &c2);
-  graphene_sincos (ez, &s3, &c3);
-
-  s1c2c3 = s1 * c2 * c3;
-  c1s2s3 = c1 * s2 * s3;
-  c1s2c3 = c1 * s2 * c3;
-  s1c2s3 = s1 * c2 * s3;
-  c1c2s3 = c1 * c2 * s3;
-  s1s2c3 = s1 * s2 * c3;
-  c1c2c3 = c1 * c2 * c3;
-  s1s2s3 = s1 * s2 * s3;
-
-  switch (order)
-    {
-    case GRAPHENE_EULER_ORDER_XYZ:
-      q->x = s1c2c3 + c1s2s3;
-      q->y = c1s2c3 - s1c2s3;
-      q->z = c1c2s3 + s1s2c3;
-      q->w = c1c2c3 - s1s2s3;
-      break;
-
-    case GRAPHENE_EULER_ORDER_YXZ:
-      q->x = s1c2c3 + c1s2s3;
-      q->y = c1s2c3 - s1c2s3;
-      q->z = c1c2s3 - s1s2c3;
-      q->w = c1c2c3 + s1s2s3;
-      break;
-
-    case GRAPHENE_EULER_ORDER_ZXY:
-      q->x = s1c2c3 - c1s2s3;
-      q->y = c1s2c3 + s1c2s3;
-      q->z = c1c2s3 + s1s2c3;
-      q->w = c1c2c3 - s1s2s3;
-      break;
-
-    case GRAPHENE_EULER_ORDER_ZYX:
-      q->x = s1c2c3 - c1s2s3;
-      q->y = c1s2c3 + s1c2s3;
-      q->z = c1c2s3 - s1s2c3;
-      q->w = c1c2c3 + s1s2s3;
-      break;
-
-    case GRAPHENE_EULER_ORDER_YZX:
-      q->x = s1c2c3 + c1s2s3;
-      q->y = c1s2c3 + s1c2s3;
-      q->z = c1c2s3 - s1s2c3;
-      q->w = c1c2c3 - s1s2s3;
-      break;
-
-    case GRAPHENE_EULER_ORDER_XZY:
-      q->x = s1c2c3 - c1s2s3;
-      q->y = c1s2c3 - s1c2s3;
-      q->z = c1c2s3 + s1s2c3;
-      q->w = c1c2c3 + s1s2s3;
-      break;
-
-    case GRAPHENE_EULER_ORDER_DEFAULT:
-      q->x = 0.f;
-      q->y = 0.f;
-      q->z = 0.f;
-      q->w = 1.f;
-      break;
-    }
+  graphene_euler_to_quaternion (e, q);
 
   return q;
 }

--- a/src/graphene-quaternion.c
+++ b/src/graphene-quaternion.c
@@ -620,10 +620,21 @@ quaternion_equal (const void *p1,
   const graphene_quaternion_t *a = p1;
   const graphene_quaternion_t *b = p2;
 
-  return fabsf (a->x - b->x) < 0.00001 &&
-         fabsf (a->y - b->y) < 0.00001 &&
-         fabsf (a->z - b->z) < 0.00001 &&
-         fabsf (a->w - b->w) < 0.00001;
+  if (graphene_fuzzy_equals (a->x, b->x, 0.00001) &&
+      graphene_fuzzy_equals (a->y, b->y, 0.00001) &&
+      graphene_fuzzy_equals (a->z, b->z, 0.00001) &&
+      graphene_fuzzy_equals (a->w, b->w, 0.00001))
+    return true;
+
+  graphene_quaternion_t i;
+  graphene_quaternion_invert (a, &i);
+  if (graphene_fuzzy_equals (i.x, b->x, 0.00001) &&
+      graphene_fuzzy_equals (i.y, b->y, 0.00001) &&
+      graphene_fuzzy_equals (i.z, b->z, 0.00001) &&
+      graphene_fuzzy_equals (i.w, b->w, 0.00001))
+    return true;
+
+  return false;
 }
 
 /**

--- a/src/tests/euler.c
+++ b/src/tests/euler.c
@@ -44,7 +44,32 @@ GRAPHENE_TEST_UNIT_BEGIN (euler_quaternion_roundtrip)
 }
 GRAPHENE_TEST_UNIT_END
 
+GRAPHENE_TEST_UNIT_BEGIN (euler_matrix_roundtrip)
+{
+  graphene_euler_t values[3];
+  unsigned int i;
+
+  graphene_euler_init_with_order (&values[0], 0.f, 0.f, 0.f, GRAPHENE_EULER_ORDER_XYZ);
+  graphene_euler_init_with_order (&values[1], 1.f, 0.f, 0.f, GRAPHENE_EULER_ORDER_XYZ);
+  graphene_euler_init_with_order (&values[2], 0.f, 1.f, 0.f, GRAPHENE_EULER_ORDER_ZYX);
+
+  for (i = 0; i < G_N_ELEMENTS (values); i++)
+    {
+      graphene_matrix_t m, check;
+      graphene_euler_t e;
+
+      graphene_euler_to_matrix (&values[i], &m);
+      graphene_euler_init_from_matrix (&e, &m, graphene_euler_get_order (&values[i]));
+
+      graphene_euler_to_matrix (&e, &check);
+
+      graphene_assert_fuzzy_matrix_equal (&m, &check, 0.01);
+    }
+}
+GRAPHENE_TEST_UNIT_END
+
 GRAPHENE_TEST_SUITE (
   GRAPHENE_TEST_UNIT ("/euler/init", euler_init)
   GRAPHENE_TEST_UNIT ("/euler/quaternion-roundtrip", euler_quaternion_roundtrip)
+  GRAPHENE_TEST_UNIT ("/euler/matrix-roundtrip", euler_matrix_roundtrip)
 )

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -52,5 +52,5 @@ foreach unit: unit_tests
                    install: true,
                    install_dir: installed_test_bindir)
 
-  test(unit, exe, args: [ '--tap', '-k' ])
+  test(unit, exe, args: [ '--tap', '-k' ], protocol: 'tap')
 endforeach

--- a/src/tests/quaternion.c
+++ b/src/tests/quaternion.c
@@ -48,15 +48,17 @@ GRAPHENE_TEST_UNIT_END
 
 GRAPHENE_TEST_UNIT_BEGIN (quaternion_operators_equal)
 {
-  graphene_quaternion_t q1, q2;
+  graphene_quaternion_t q1, q2, q3;
 
   graphene_quaternion_init (&q1, 1.f, 1.f, 1.f, 1.f);
-  graphene_quaternion_invert (&q1, &q2);
+  graphene_quaternion_init (&q2, 1.f, 2.f, 3.f, 1.f);
+  graphene_quaternion_invert (&q1, &q3);
 
   g_assert_true (graphene_quaternion_equal (&q1, &q1));
   g_assert_false (graphene_quaternion_equal (&q1, NULL));
   g_assert_false (graphene_quaternion_equal (NULL, &q1));
   g_assert_false (graphene_quaternion_equal (&q1, &q2));
+  g_assert_true (graphene_quaternion_equal (&q1, &q3));
 }
 GRAPHENE_TEST_UNIT_END
 


### PR DESCRIPTION
Fixes #96 
Closes #150 

Proposed changes:

 - reimplement the conversion between `graphene_euler_t`, `graphene_matrix_t`, and `graphene_quaternion_t`
 - extensively document the conventions used by `graphene_euler_t`
 - add more rotation orders to `graphene_euler_order_t`
 - fix the equality operator for `graphene_quaternion_t`

Test suite changes:

 - cherry pick the roundtrip test from #150 
 - update the unit for `graphene_quaternion_t`
