### PR TITLE
Remove float equality comparisons

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -96,6 +96,7 @@ else
     '-Wcast-align',
     '-Wno-unused-local-typedefs',
     '-Werror=float-conversion',
+    '-Werror=float-equal',
     '-Werror=redundant-decls',
     '-Werror=missing-prototypes',
     '-Werror=missing-declarations',

--- a/meson.build
+++ b/meson.build
@@ -171,6 +171,15 @@ conf.set('HAVE_SINCOSF',
   description: 'Define if sincosf() is available',
 )
 
+conf.set('HAVE_ISINFF',
+  cc.has_function('isinff',
+    prefix: '#include <math.h>',
+    args: [ '-D_GNU_SOURCE' ],
+    dependencies: mathlib,
+  ),
+  description: 'Define is isinff() is available',
+)
+
 # Debugging
 debug_flags = []
 buildtype = get_option('buildtype')

--- a/src/graphene-matrix.c
+++ b/src/graphene-matrix.c
@@ -1862,7 +1862,7 @@ matrix_decompose_2d (const graphene_matrix_t *m,
 
   angle = atan2f (row0y, row0x);
 
-  if (angle != 0.f)
+  if (fabsf (angle) > FLT_EPSILON)
     {
       double sn = -row0y, cs = row0x;
       double m11 = row0x, m12 = row0y;
@@ -2066,9 +2066,9 @@ graphene_matrix_interpolate (const graphene_matrix_t *a,
         }
 
       /* Do not rotate "the long way around" */
-      if (rotate_a == 0.f)
+      if (fabs (rotate_a) <= DBL_EPSILON)
         rotate_a = 360;
-      if (rotate_b == 0.f)
+      if (fabs (rotate_b) <= DBL_EPSILON)
         rotate_b = 360;
 
       if (fabs (rotate_a - rotate_b) > 180)

--- a/src/graphene-simd4f.h
+++ b/src/graphene-simd4f.h
@@ -31,6 +31,7 @@
 /* needed for memcpy() */
 #include <string.h>
 #include <math.h>
+#include <float.h>
 
 #include "graphene-config.h"
 #include "graphene-macros.h"
@@ -1727,9 +1728,9 @@ graphene_simd4f_is_zero4 (const graphene_simd4f_t v)
 static inline bool
 graphene_simd4f_is_zero3 (const graphene_simd4f_t v)
 {
-  return graphene_simd4f_get_x (v) == 0.f &&
-         graphene_simd4f_get_y (v) == 0.f &&
-         graphene_simd4f_get_z (v) == 0.f;
+  return fabsf (graphene_simd4f_get_x (v)) <= FLT_EPSILON &&
+         fabsf (graphene_simd4f_get_y (v)) <= FLT_EPSILON &&
+         fabsf (graphene_simd4f_get_z (v)) <= FLT_EPSILON;
 }
 
 /**
@@ -1746,8 +1747,8 @@ graphene_simd4f_is_zero3 (const graphene_simd4f_t v)
 static inline bool
 graphene_simd4f_is_zero2 (const graphene_simd4f_t v)
 {
-  return graphene_simd4f_get_x (v) == 0.f &&
-         graphene_simd4f_get_y (v) == 0.f;
+  return fabsf (graphene_simd4f_get_x (v)) <= FLT_EPSILON &&
+         fabsf (graphene_simd4f_get_y (v)) <= FLT_EPSILON;
 }
 
 /**

--- a/src/graphene-simd4x4f.h
+++ b/src/graphene-simd4x4f.h
@@ -969,7 +969,7 @@ graphene_simd4x4f_inverse (const graphene_simd4x4f_t *m,
   const graphene_simd4f_t d0 = graphene_simd4f_mul (r1_sum, r0);
   const graphene_simd4f_t d1 = graphene_simd4f_add (d0, graphene_simd4f_merge_high (d0, d0));
   const graphene_simd4f_t det = graphene_simd4f_sub (d1, graphene_simd4f_splat_y (d1));
-  if (graphene_simd4f_get_x (det) != 0.f)
+  if (fabsf (graphene_simd4f_get_x (det)) >= FLT_EPSILON)
     {
       const graphene_simd4f_t invdet = graphene_simd4f_splat_x (graphene_simd4f_div (graphene_simd4f_splat (1.0f), det));
 

--- a/src/graphene-triangle.c
+++ b/src/graphene-triangle.c
@@ -343,7 +343,7 @@ graphene_triangle_get_uv (const graphene_triangle_t *t,
   dot12 = graphene_vec3_dot (&v1, &v2);
 
   denom = dot00 * dot11 - dot01 * dot01;
-  if (denom == 0.f)
+  if (fabsf (denom) <= FLT_EPSILON)
     return false;
 
   inv_denom = 1.f / denom;

--- a/src/graphene-vectors.c
+++ b/src/graphene-vectors.c
@@ -325,7 +325,7 @@ void
 graphene_vec2_normalize (const graphene_vec2_t *v,
                          graphene_vec2_t       *res)
 {
-  if (graphene_vec2_length (v) != 0.f)
+  if (fabsf (graphene_vec2_length (v)) > FLT_EPSILON)
     res->value = graphene_simd4f_normalize2 (v->value);
   else
     res->value = graphene_simd4f_init_zero ();
@@ -915,7 +915,7 @@ void
 graphene_vec3_normalize (const graphene_vec3_t *v,
                          graphene_vec3_t       *res)
 {
-  if (graphene_vec3_length (v) != 0.f)
+  if (fabsf (graphene_vec3_length (v)) > FLT_EPSILON)
     res->value = graphene_simd4f_normalize3 (v->value);
   else
     res->value = graphene_simd4f_init_zero ();
@@ -1667,7 +1667,7 @@ void
 graphene_vec4_normalize (const graphene_vec4_t *v,
                          graphene_vec4_t       *res)
 {
-  if (graphene_vec4_length (v) != 0.f)
+  if (fabsf (graphene_vec4_length (v)) > FLT_EPSILON)
     res->value = graphene_simd4f_normalize4 (v->value);
   else
     res->value = graphene_simd4f_init_zero ();


### PR DESCRIPTION
Stop comparing floating point values for equality; it's not safe to do.

Fixes #134