### PR TITLE
CI: work around msys2 toolchain upgrade issues on appveyor

### DIFF
--- a/.appveyor/msys2-pre.sh
+++ b/.appveyor/msys2-pre.sh
@@ -5,5 +5,9 @@ set -e
 # Disable slow diskspace check
 sed -i 's/^CheckSpace/#CheckSpace/g' /etc/pacman.conf
 
+# Workaround gcc9 update issues
+pacman -R --noconfirm mingw-w64-i686-gcc-ada mingw-w64-i686-gcc-objc || true;
+pacman -R --noconfirm mingw-w64-x86_64-gcc-ada mingw-w64-x86_64-gcc-objc || true;
+
 # System upgrade
 pacman --noconfirm -Syyuu

--- a/.appveyor/msys2.sh
+++ b/.appveyor/msys2.sh
@@ -14,7 +14,7 @@ pacman --noconfirm -Suy
 # Install the required packages
 pacman --noconfirm -S --needed \
     base-devel \
-    mingw-w64-$MSYS2_ARCH-gobject-introspection
+    mingw-w64-$MSYS2_ARCH-gobject-introspection \
     mingw-w64-$MSYS2_ARCH-meson \
     mingw-w64-$MSYS2_ARCH-ninja \
     mingw-w64-$MSYS2_ARCH-pkg-config \


### PR DESCRIPTION
error: failed to prepare transaction (could not satisfy dependencies)
:: installing mingw-w64-i686-gcc (9.1.0-1) breaks dependency 'mingw-w64-i686-gcc=7.3.0-2' required by mingw-w64-i686-gcc-ada
:: installing mingw-w64-i686-gcc (9.1.0-1) breaks dependency 'mingw-w64-i686-gcc=7.3.0-2' required by mingw-w64-i686-gcc-objc
:: installing mingw-w64-x86_64-gcc (9.1.0-1) breaks dependency 'mingw-w64-x86_64-gcc=8.2.0-3' required by mingw-w64-x86_64-gcc-ada
:: installing mingw-w64-x86_64-gcc (9.1.0-1) breaks dependency 'mingw-w64-x86_64-gcc=8.2.0-3' required by mingw-w64-x86_64-gcc-objc
