### PR TITLE
Fix ARM NEON support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -262,12 +262,16 @@ int main () {
     c = _mm_xor_si128 (a, b);
     return 0;
 }'''
-  if cc.compiles(sse_prog, name: 'SSE intrinsics')
+  if cc.get_id() != 'msvc'
+    test_sse2_cflags = ['-mfpmath=sse', '-msse', '-msse2']
+  else
+    test_sse2_cflags = []
+  endif
+
+  if cc.compiles(sse_prog, args: test_sse2_cflags, name: 'SSE intrinsics')
     graphene_conf.set('GRAPHENE_HAS_SSE', 1)
-    if cc.get_id() != 'msvc'
-      sse2_cflags += ['-mfpmath=sse', '-msse', '-msse2']
-    endif
-    common_cflags += sse2_cflags
+    sse2_cflags = test_sse2_cflags
+    common_cflags += test_sse2_cflags
     graphene_simd += [ 'sse2' ]
   endif
 endif

--- a/meson.build
+++ b/meson.build
@@ -324,15 +324,17 @@ int main () {
     float32x4_t c = vreinterpretq_f32_u32 (veorq_u32 (vreinterpretq_u32_f32 (s), __mask)); \
     return 0;
 }'''
-  if cc.compiles(neon_prog, name: 'ARM NEON intrinsics')
+  test_neon_cflags = ['-mfpu=neon']
+
+  if host_system == 'android'
+    test_neon_cflags += ['-mfloat-abi=softfp']
+  endif
+
+  if cc.compiles(neon_prog, args: test_neon_cflags, name: 'ARM NEON intrinsics')
     graphene_conf.set('GRAPHENE_HAS_ARM_NEON', 1)
-    neon_cflags += ['-mfpu=neon']
 
-    if host_system == 'android'
-      neon_cflags += ['-mfloat-abi=softfp']
-    endif
-
-    common_cflags += neon_cflags
+    neon_cflags = test_neon_cflags
+    common_cflags += test_neon_cflags
     graphene_simd += [ 'neon' ]
   endif
 endif

--- a/src/graphene-simd4f.h
+++ b/src/graphene-simd4f.h
@@ -1356,7 +1356,7 @@ typedef float32x2_t graphene_simd2f_t;
 
 # define graphene_simd4f_cmp_gt(a,b) \
   (__extension__ ({ \
-    const uint8x16_t __mask = vreinterpretq_u8_u32 (vcgeq_f32 ((a), (b))); \
+    const uint8x16_t __mask = vreinterpretq_u8_u32 (vcgtq_f32 ((a), (b))); \
     (bool) (_graphene_movemask (__mask) != 0); \
   }))
 

--- a/src/graphene-simd4f.h
+++ b/src/graphene-simd4f.h
@@ -1047,7 +1047,6 @@ typedef int graphene_simd4i_t __attribute__((vector_size (16)));
 #elif !defined(__GI_SCANNER__) && defined(GRAPHENE_USE_ARM_NEON)
 
 /* ARM Neon implementation of SIMD4f */
-# warning "The ARM Neon implementation of graphene_simd4f_t is experimental."
 
 /* Union type used for single lane reading without memcpy */
 typedef union {

--- a/src/graphene-simd4f.h
+++ b/src/graphene-simd4f.h
@@ -1327,37 +1327,56 @@ typedef float32x2_t graphene_simd2f_t;
 
 # define graphene_simd4f_cmp_eq(a,b) \
   (__extension__ ({ \
-    const uint8x16_t __mask = vreinterpretq_u8_u32 (vceqq_f32 ((a), (b))); \
-    (bool) (_graphene_movemask (__mask) != 0); \
+    const uint32x4_t __mask = vceqq_f32 ((a), (b)); \
+    (bool) (vgetq_lane_u32 (__mask, 0) != 0 && \
+            vgetq_lane_u32 (__mask, 1) != 0 && \
+            vgetq_lane_u32 (__mask, 2) != 0 && \
+            vgetq_lane_u32 (__mask, 3) != 0); \
   }))
 
 # define graphene_simd4f_cmp_neq(a,b) \
   (__extension__ ({ \
-    !graphene_simd4f_cmp_eq (a, b); \
+    const uint32x4_t __mask = vceqq_f32 ((a), (b)); \
+    (bool) (vgetq_lane_u32 (__mask, 0) == 0 || \
+            vgetq_lane_u32 (__mask, 1) == 0 || \
+            vgetq_lane_u32 (__mask, 2) == 0 || \
+            vgetq_lane_u32 (__mask, 3) == 0); \
   }))
 
 # define graphene_simd4f_cmp_lt(a,b) \
   (__extension__ ({ \
-    const uint8x16_t __mask = vreinterpretq_u8_u32 (vcltq_f32 ((a), (b))); \
-    (bool) (_graphene_movemask (__mask) != 0); \
+    const uint32x4_t __mask = vcltq_f32 ((a), (b)); \
+    (bool) (vgetq_lane_u32 (__mask, 0) != 0 && \
+            vgetq_lane_u32 (__mask, 1) != 0 && \
+            vgetq_lane_u32 (__mask, 2) != 0 && \
+            vgetq_lane_u32 (__mask, 3) != 0); \
   }))
 
 # define graphene_simd4f_cmp_le(a,b) \
   (__extension__ ({ \
-    const uint8x16_t __mask = vreinterpretq_u8_u32 (vcleq_f32 ((a), (b))); \
-    (bool) (_graphene_movemask (__mask) != 0); \
+    const uint32x4_t __mask = vcleq_f32 ((a), (b)); \
+    (bool) (vgetq_lane_u32 (__mask, 0) != 0 && \
+            vgetq_lane_u32 (__mask, 1) != 0 && \
+            vgetq_lane_u32 (__mask, 2) != 0 && \
+            vgetq_lane_u32 (__mask, 3) != 0); \
   }))
 
 # define graphene_simd4f_cmp_ge(a,b) \
   (__extension__ ({ \
-    const uint8x16_t __mask = vreinterpretq_u8_u32 (vcgeq_f32 ((a), (b))); \
-    (bool) (_graphene_movemask (__mask) != 0); \
+    const uint32x4_t __mask = vcgeq_f32 ((a), (b)); \
+    (bool) (vgetq_lane_u32 (__mask, 0) != 0 && \
+            vgetq_lane_u32 (__mask, 1) != 0 && \
+            vgetq_lane_u32 (__mask, 2) != 0 && \
+            vgetq_lane_u32 (__mask, 3) != 0); \
   }))
 
 # define graphene_simd4f_cmp_gt(a,b) \
   (__extension__ ({ \
-    const uint8x16_t __mask = vreinterpretq_u8_u32 (vcgtq_f32 ((a), (b))); \
-    (bool) (_graphene_movemask (__mask) != 0); \
+    const uint32x4_t __mask = vcgtq_f32 ((a), (b)); \
+    (bool) (vgetq_lane_u32 (__mask, 0) != 0 && \
+            vgetq_lane_u32 (__mask, 1) != 0 && \
+            vgetq_lane_u32 (__mask, 2) != 0 && \
+            vgetq_lane_u32 (__mask, 3) != 0); \
   }))
 
 # define graphene_simd4f_neg(s) \

--- a/src/graphene-simd4f.h
+++ b/src/graphene-simd4f.h
@@ -1327,22 +1327,13 @@ typedef float32x2_t graphene_simd2f_t;
 
 # define graphene_simd4f_cmp_eq(a,b) \
   (__extension__ ({ \
-    const graphene_simd4f_union_t __u_a = { (a) }; \
-    const graphene_simd4f_union_t __u_b = { (b) }; \
-    (bool) (__u_a.f[0] == __u_b.f[0] && \
-            __u_a.f[1] == __u_b.f[1] && \
-            __u_a.f[2] == __u_b.f[2] && \
-            __u_a.f[3] == __u_b.f[3]); \
+    const uint8x16_t __mask = vreinterpretq_u8_u32 (vceqq_f32 ((a), (b))); \
+    (bool) (_graphene_movemask (__mask) != 0); \
   }))
 
 # define graphene_simd4f_cmp_neq(a,b) \
   (__extension__ ({ \
-    const graphene_simd4f_union_t __u_a = { (a) }; \
-    const graphene_simd4f_union_t __u_b = { (b) }; \
-    (bool) (__u_a.f[0] != __u_b.f[0] && \
-            __u_a.f[1] != __u_b.f[1] && \
-            __u_a.f[2] != __u_b.f[2] && \
-            __u_a.f[3] != __u_b.f[3]); \
+    !graphene_simd4f_cmp_eq (a, b); \
   }))
 
 # define graphene_simd4f_cmp_lt(a,b) \


### PR DESCRIPTION
Fixes: #97, #147, #148 

Proposed changes:

 - Properly detect ARM NEON support in the toolchain
 - Change the implementation for `graphene_simd4f_cmp_*` on ARM NEON
 - Remove the compiler warning raised when using the ARM NEON implementation
   of `graphene_simd4f_t`

Test suite changes:

 - None
