### PR TITLE
graphene_quaternion_slerp: Always use the shortest path

### DIFF
--- a/src/graphene-quaternion.c
+++ b/src/graphene-quaternion.c
@@ -281,8 +281,16 @@ graphene_quaternion_slerp (const graphene_quaternion_t *a,
 {
   graphene_simd4f_t v_a = graphene_simd4f_init (a->x, a->y, a->z, a->w);
   graphene_simd4f_t v_b = graphene_simd4f_init (b->x, b->y, b->z, b->w);
+  float left_sign = 1;
 
   float dot = CLAMP (graphene_simd4f_get_x (graphene_simd4f_dot4 (v_a, v_b)), -1.f, 1.f);
+
+  /* Ensure we use the shortest path to the new angle */
+  if (dot < 0)
+    {
+      left_sign = -1;
+      dot = -dot;
+    }
 
   if (graphene_approx_val (dot, 1.f))
     {
@@ -299,7 +307,7 @@ graphene_quaternion_slerp (const graphene_quaternion_t *a,
   graphene_simd4f_t right = graphene_simd4f_init (b->x, b->y, b->z, b->w);
   graphene_simd4f_t sum;
 
-  left = graphene_simd4f_mul (left, graphene_simd4f_splat (left_v));
+  left = graphene_simd4f_mul (left, graphene_simd4f_splat (left_v * left_sign));
   right = graphene_simd4f_mul (right, graphene_simd4f_splat (right_v));
   sum = graphene_simd4f_add (left, right);
 


### PR DESCRIPTION
As discussed in the "Invertin Quaternions" section in:
 http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/slerp/

We need to check if the dot product (i.e. cos(theta/2)) is
negative. If so, that means the rotation is > 180 degrees and
we should invert the rotation so as to take the shortest path.

Without this rotation animations in gthree get really weird when you
pass 360 degrees. I.e. interpolation is slow clockwise until 360
deg, where it switches to a very fast counter-clockwise rotation only
to then continue the slow clockwise rotation.
