### PR TITLE
Add lerp operator for vector types

### DIFF
--- a/doc/graphene-sections.txt
+++ b/doc/graphene-sections.txt
@@ -505,6 +505,7 @@ graphene_triangle_equal
 
 <SECTION>
 <FILE>graphene-vectors</FILE>
+<SUBSECTION 2-components vector>
 GRAPHENE_VEC2_LEN
 graphene_vec2_t
 graphene_vec2_alloc
@@ -526,13 +527,14 @@ graphene_vec2_equal
 graphene_vec2_near
 graphene_vec2_min
 graphene_vec2_max
+graphene_vec2_interpolate
 graphene_vec2_get_x
 graphene_vec2_get_y
 graphene_vec2_zero
 graphene_vec2_one
 graphene_vec2_x_axis
 graphene_vec2_y_axis
-<SUBSECTION>
+<SUBSECTION 3-components vector>
 GRAPHENE_VEC3_LEN
 graphene_vec3_t
 graphene_vec3_alloc
@@ -555,6 +557,7 @@ graphene_vec3_equal
 graphene_vec3_near
 graphene_vec3_min
 graphene_vec3_max
+graphene_vec3_interpolate
 graphene_vec3_get_x
 graphene_vec3_get_y
 graphene_vec3_get_z
@@ -568,7 +571,7 @@ graphene_vec3_one
 graphene_vec3_x_axis
 graphene_vec3_y_axis
 graphene_vec3_z_axis
-<SUBSECTION>
+<SUBSECTION 4-components vector>
 GRAPHENE_VEC4_LEN
 graphene_vec4_t
 graphene_vec4_alloc
@@ -592,6 +595,7 @@ graphene_vec4_equal
 graphene_vec4_near
 graphene_vec4_min
 graphene_vec4_max
+graphene_vec4_interpolate
 graphene_vec4_get_x
 graphene_vec4_get_y
 graphene_vec4_get_z

--- a/src/graphene-vec2.h
+++ b/src/graphene-vec2.h
@@ -111,6 +111,11 @@ GRAPHENE_AVAILABLE_IN_1_0
 void                    graphene_vec2_max               (const graphene_vec2_t *a,
                                                          const graphene_vec2_t *b,
                                                          graphene_vec2_t       *res);
+GRAPHENE_AVAILABLE_IN_1_10
+void                    graphene_vec2_interpolate       (const graphene_vec2_t *v1,
+                                                         const graphene_vec2_t *v2,
+                                                         double                 factor,
+                                                         graphene_vec2_t       *res);
 
 GRAPHENE_AVAILABLE_IN_1_0
 float                   graphene_vec2_get_x             (const graphene_vec2_t *v);

--- a/src/graphene-vec3.h
+++ b/src/graphene-vec3.h
@@ -115,6 +115,11 @@ GRAPHENE_AVAILABLE_IN_1_0
 void                    graphene_vec3_max               (const graphene_vec3_t *a,
                                                          const graphene_vec3_t *b,
                                                          graphene_vec3_t       *res);
+GRAPHENE_AVAILABLE_IN_1_10
+void                    graphene_vec3_interpolate       (const graphene_vec3_t *v1,
+                                                         const graphene_vec3_t *v2,
+                                                         double                 factor,
+                                                         graphene_vec3_t       *res);
 
 GRAPHENE_AVAILABLE_IN_1_0
 float                   graphene_vec3_get_x             (const graphene_vec3_t *v);

--- a/src/graphene-vec4.h
+++ b/src/graphene-vec4.h
@@ -120,6 +120,11 @@ GRAPHENE_AVAILABLE_IN_1_0
 void                    graphene_vec4_max               (const graphene_vec4_t *a,
                                                          const graphene_vec4_t *b,
                                                          graphene_vec4_t       *res);
+GRAPHENE_AVAILABLE_IN_1_10
+void                    graphene_vec4_interpolate       (const graphene_vec4_t *v1,
+                                                         const graphene_vec4_t *v2,
+                                                         double                 factor,
+                                                         graphene_vec4_t       *res);
 
 GRAPHENE_AVAILABLE_IN_1_0
 float                   graphene_vec4_get_x             (const graphene_vec4_t *v);

--- a/src/graphene-vectors.c
+++ b/src/graphene-vectors.c
@@ -460,6 +460,26 @@ graphene_vec2_near (const graphene_vec2_t *v1,
   return graphene_simd4f_get_x (graphene_simd4f_dot2 (d, d)) < epsilon_sq;
 }
 
+/**
+ * graphene_vec2_interpolate:
+ * @v1: a #graphene_vec2_t
+ * @v2: a #graphene_vec2_t
+ * @factor: the interpolation factor
+ * @res: (out caller-allocates): the interpolated vector
+ *
+ * Linearly interpolates @v1 and @v2 using the given @factor.
+ *
+ * Since: 1.10
+ */
+void
+graphene_vec2_interpolate (const graphene_vec2_t *v1,
+                           const graphene_vec2_t *v2,
+                           double                 factor,
+                           graphene_vec2_t       *res)
+{
+  res->value = graphene_simd4f_interpolate (v1->value, v2->value, (float) factor);
+}
+
 enum {
   VEC2_ZERO,
   VEC2_ONE,
@@ -1137,6 +1157,26 @@ graphene_vec3_near (const graphene_vec3_t *v1,
   float epsilon_sq = epsilon * epsilon;
 
   return graphene_simd4f_dot3_scalar (d, d) < epsilon_sq;
+}
+
+/**
+ * graphene_vec3_interpolate:
+ * @v1: a #graphene_vec3_t
+ * @v2: a #graphene_vec3_t
+ * @factor: the interpolation factor
+ * @res: (out caller-allocates): the interpolated vector
+ *
+ * Linearly interpolates @v1 and @v2 using the given @factor.
+ *
+ * Since: 1.10
+ */
+void
+graphene_vec3_interpolate (const graphene_vec3_t *v1,
+                           const graphene_vec3_t *v2,
+                           double                 factor,
+                           graphene_vec3_t       *res)
+{
+  res->value = graphene_simd4f_interpolate (v1->value, v2->value, (float) factor);
 }
 
 enum {
@@ -1834,6 +1874,26 @@ graphene_vec4_near (const graphene_vec4_t *v1,
   float epsilon_sq = epsilon * epsilon;
 
   return graphene_simd4f_get_x (graphene_simd4f_dot4 (d, d)) < epsilon_sq;
+}
+
+/**
+ * graphene_vec4_interpolate:
+ * @v1: a #graphene_vec4_t
+ * @v2: a #graphene_vec4_t
+ * @factor: the interpolation factor
+ * @res: (out caller-allocates): the interpolated vector
+ *
+ * Linearly interpolates @v1 and @v2 using the given @factor.
+ *
+ * Since: 1.10
+ */
+void
+graphene_vec4_interpolate (const graphene_vec4_t *v1,
+                           const graphene_vec4_t *v2,
+                           double                 factor,
+                           graphene_vec4_t       *res)
+{
+  res->value = graphene_simd4f_interpolate (v1->value, v2->value, (float) factor);
 }
 
 enum {


### PR DESCRIPTION
We have lerp() for every other vector-like type, including the SIMD
implementation, but we don't have one for the 2, 3, and 4-component
vector type wrappers.

Proposed changes:

 - Add `graphene_vec2_interpolate()`
 - Add `graphene_vec3_interpolate()`
 - Add `graphene_vec4_interpolate()`