### PR TITLE
Add quaternion operators

### DIFF
--- a/doc/graphene-sections.txt
+++ b/doc/graphene-sections.txt
@@ -297,6 +297,7 @@ graphene_quaternion_equal
 graphene_quaternion_dot
 graphene_quaternion_invert
 graphene_quaternion_normalize
+graphene_quaternion_add
 graphene_quaternion_multiply
 graphene_quaternion_scale
 graphene_quaternion_slerp

--- a/doc/graphene-sections.txt
+++ b/doc/graphene-sections.txt
@@ -297,6 +297,8 @@ graphene_quaternion_equal
 graphene_quaternion_dot
 graphene_quaternion_invert
 graphene_quaternion_normalize
+graphene_quaternion_multiply
+graphene_quaternion_scale
 graphene_quaternion_slerp
 </SECTION>
 

--- a/src/graphene-quaternion.c
+++ b/src/graphene-quaternion.c
@@ -656,3 +656,52 @@ graphene_quaternion_normalize (const graphene_quaternion_t *q,
 
   graphene_quaternion_init_from_simd4f (res, v_q);
 }
+
+/**
+ * graphene_quaternion_multiply:
+ * @a: a #graphene_quaternion_t
+ * @b: a #graphene_quaternion_t
+ * @res: (out caller-allocates): the result of the operation
+ *
+ * Multiplies two #graphene_quaternion_t @a and @b.
+ *
+ * Since: 1.10
+ */
+void
+graphene_quaternion_multiply (const graphene_quaternion_t *a,
+                              const graphene_quaternion_t *b,
+                              graphene_quaternion_t       *res)
+{
+  /* See:
+   *
+   * http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/code/index.htm
+   */
+  float x = a->x * b->w + a->w * b->x + a->y * b->z - a->z * b->y;
+  float y = a->y * b->w + a->w * b->y + a->z * b->x - a->x * b->z;
+  float z = a->z * b->w + a->w * b->z + a->x * b->y - a->y * b->x;
+  float w = a->w * b->w - a->x * b->x - a->y * b->y - a->z * b->z;
+
+  graphene_quaternion_init (res, x, y, z, w);
+}
+
+/**
+ * graphene_quaternion_scale:
+ * @q: a #graphene_quaternion_t
+ * @factor: a scaling factor
+ * @res: (out caller-allocates): the result of the operation
+ *
+ * Scales all the elements of a #graphene_quaternion_t @q using
+ * the given scalar factor.
+ *
+ * Since: 1.10
+ */
+void
+graphene_quaternion_scale (const graphene_quaternion_t *q,
+                           float                        factor,
+                           graphene_quaternion_t       *res)
+{
+  graphene_simd4f_t s =
+    graphene_simd4f_mul (graphene_simd4f_init (q->x, q->y, q->z, q->w),
+                         graphene_simd4f_splat (factor));
+  graphene_quaternion_init_from_simd4f (res, s);
+}

--- a/src/graphene-quaternion.c
+++ b/src/graphene-quaternion.c
@@ -621,7 +621,8 @@ graphene_quaternion_dot (const graphene_quaternion_t *a,
  * @res: (out caller-allocates): return location for the inverted
  *   quaternion
  *
- * Inverts a #graphene_quaternion_t.
+ * Inverts a #graphene_quaternion_t, and returns the conjugate
+ * quaternion of @q.
  *
  * Since: 1.0
  */
@@ -704,4 +705,26 @@ graphene_quaternion_scale (const graphene_quaternion_t *q,
     graphene_simd4f_mul (graphene_simd4f_init (q->x, q->y, q->z, q->w),
                          graphene_simd4f_splat (factor));
   graphene_quaternion_init_from_simd4f (res, s);
+}
+
+/**
+ * graphene_quaternion_add:
+ * @a: a #graphene_quaternion_t
+ * @b: a #graphene_quaternion_t
+ * @res: (out caller-allocates): the result of the operation
+ *
+ * Adds two #graphene_quaternion_t @a and @b.
+ *
+ * Since: 1.10
+ */
+void
+graphene_quaternion_add (const graphene_quaternion_t *a,
+                         const graphene_quaternion_t *b,
+                         graphene_quaternion_t       *res)
+{
+  graphene_simd4f_t sa = graphene_simd4f_init (a->x, a->y, a->z, a->w);
+  graphene_simd4f_t sb = graphene_simd4f_init (b->x, b->y, b->z, b->w);
+  graphene_simd4f_t sr = graphene_simd4f_add (sa, sb);
+
+  graphene_quaternion_init_from_simd4f (res, sr);
 }

--- a/src/graphene-quaternion.h
+++ b/src/graphene-quaternion.h
@@ -131,5 +131,13 @@ void                    graphene_quaternion_slerp                       (const g
                                                                          const graphene_quaternion_t *b,
                                                                          float                        factor,
                                                                          graphene_quaternion_t       *res);
+GRAPHENE_AVAILABLE_IN_1_10
+void                    graphene_quaternion_multiply                    (const graphene_quaternion_t *a,
+                                                                         const graphene_quaternion_t *b,
+                                                                         graphene_quaternion_t       *res);
+GRAPHENE_AVAILABLE_IN_1_10
+void                    graphene_quaternion_scale                       (const graphene_quaternion_t *q,
+                                                                         float                        factor,
+                                                                         graphene_quaternion_t       *res);
 
 GRAPHENE_END_DECLS

--- a/src/graphene-quaternion.h
+++ b/src/graphene-quaternion.h
@@ -139,5 +139,9 @@ GRAPHENE_AVAILABLE_IN_1_10
 void                    graphene_quaternion_scale                       (const graphene_quaternion_t *q,
                                                                          float                        factor,
                                                                          graphene_quaternion_t       *res);
+GRAPHENE_AVAILABLE_IN_1_10
+void                    graphene_quaternion_add                         (const graphene_quaternion_t *a,
+                                                                         const graphene_quaternion_t *b,
+                                                                         graphene_quaternion_t       *res);
 
 GRAPHENE_END_DECLS


### PR DESCRIPTION
The operators coverage for `graphene_quaternion_t` is a bit low. As the fields in the quaternion structure are private, in order to implement common operations, like adding, multiplying, and scaling, you'd have to convert a quaternion into a vec4, operate on the vec4, and then turn the vec4 back into a quaternion. This is not really efficient, and could be easily solved by providing an actual API.

Proposed changes:

 - Add `graphene_quaternion_add()`
 - Add `graphene_quaternion_multiply()`
 - Add `graphene_quaternion_scale()`