### PR TITLE
Last minute API additions for Gthree

### DIFF
--- a/doc/graphene-sections.txt
+++ b/doc/graphene-sections.txt
@@ -512,6 +512,7 @@ graphene_triangle_get_normal
 graphene_triangle_get_plane
 graphene_triangle_get_bounding_box
 graphene_triangle_get_barycoords
+graphene_triangle_get_uv
 graphene_triangle_contains_point
 graphene_triangle_equal
 </SECTION>

--- a/doc/graphene-sections.txt
+++ b/doc/graphene-sections.txt
@@ -496,6 +496,7 @@ graphene_triangle_alloc
 graphene_triangle_free
 graphene_triangle_init_from_point3d
 graphene_triangle_init_from_vec3
+graphene_triangle_init_from_float
 graphene_triangle_get_points
 graphene_triangle_get_vertices
 graphene_triangle_get_area

--- a/doc/graphene-sections.txt
+++ b/doc/graphene-sections.txt
@@ -320,6 +320,13 @@ graphene_ray_get_distance_to_point
 graphene_ray_get_distance_to_plane
 graphene_ray_get_closest_point_to_point
 graphene_ray_equal
+graphene_ray_intersection_kind_t
+graphene_ray_intersect_sphere
+graphene_ray_intersects_sphere
+graphene_ray_intersect_box
+graphene_ray_intersects_box
+graphene_ray_intersect_triangle
+graphene_ray_intersects_triangle
 </SECTION>
 
 <SECTION>

--- a/include/graphene-ray.h
+++ b/include/graphene-ray.h
@@ -51,6 +51,24 @@ struct _graphene_ray_t
   GRAPHENE_PRIVATE_FIELD (graphene_vec3_t, direction);
 };
 
+/**
+ * graphene_ray_intersection_kind_t:
+ * @GRAPHENE_RAY_INTERSECTION_KIND_NONE: No intersection
+ * @GRAPHENE_RAY_INTERSECTION_KIND_ENTER: The ray is entering the intersected
+ *   object
+ * @GRAPHENE_RAY_INTERSECTION_KIND_LEAVE: The ray is leaving the intersected
+ *   object
+ *
+ * The type of intersection.
+ *
+ * Since: 1.10
+ */
+typedef enum {
+  GRAPHENE_RAY_INTERSECTION_KIND_NONE,
+  GRAPHENE_RAY_INTERSECTION_KIND_ENTER,
+  GRAPHENE_RAY_INTERSECTION_KIND_LEAVE,
+} graphene_ray_intersection_kind_t;
+
 GRAPHENE_AVAILABLE_IN_1_4
 graphene_ray_t *                graphene_ray_alloc                  (void);
 GRAPHENE_AVAILABLE_IN_1_4
@@ -90,8 +108,30 @@ bool                            graphene_ray_equal                  (const graph
                                                                      const graphene_ray_t     *b);
 
 GRAPHENE_AVAILABLE_IN_1_4
-void                            graphene_ray_get_closest_point_to_point   (const graphene_ray_t     *r,
-                                                                           const graphene_point3d_t *p,
-                                                                           graphene_point3d_t       *res);
+void                            graphene_ray_get_closest_point_to_point (const graphene_ray_t     *r,
+                                                                         const graphene_point3d_t *p,
+                                                                         graphene_point3d_t       *res);
+
+GRAPHENE_AVAILABLE_IN_1_10
+graphene_ray_intersection_kind_t graphene_ray_intersect_sphere          (const graphene_ray_t    *r,
+                                                                         const graphene_sphere_t *s,
+                                                                         float                   *t_out);
+GRAPHENE_AVAILABLE_IN_1_10
+bool                            graphene_ray_intersects_sphere          (const graphene_ray_t    *r,
+                                                                         const graphene_sphere_t *s);
+GRAPHENE_AVAILABLE_IN_1_10
+graphene_ray_intersection_kind_t graphene_ray_intersect_box             (const graphene_ray_t    *r,
+                                                                         const graphene_box_t    *b,
+                                                                         float                   *t_out);
+GRAPHENE_AVAILABLE_IN_1_10
+bool                            graphene_ray_intersects_box             (const graphene_ray_t    *r,
+                                                                         const graphene_box_t    *b);
+GRAPHENE_AVAILABLE_IN_1_10
+graphene_ray_intersection_kind_t graphene_ray_intersect_triangle        (const graphene_ray_t      *r,
+                                                                         const graphene_triangle_t *t,
+                                                                         float                     *t_out);
+GRAPHENE_AVAILABLE_IN_1_10
+bool                            graphene_ray_intersects_triangle        (const graphene_ray_t      *r,
+                                                                         const graphene_triangle_t *t);
 
 GRAPHENE_END_DECLS

--- a/include/graphene-triangle.h
+++ b/include/graphene-triangle.h
@@ -64,7 +64,11 @@ graphene_triangle_t *   graphene_triangle_init_from_vec3        (graphene_triang
                                                                  const graphene_vec3_t     *a,
                                                                  const graphene_vec3_t     *b,
                                                                  const graphene_vec3_t     *c);
-
+GRAPHENE_AVAILABLE_IN_1_10
+graphene_triangle_t *   graphene_triangle_init_from_float       (graphene_triangle_t       *t,
+                                                                 const float               *a,
+                                                                 const float               *b,
+                                                                 const float               *c);
 GRAPHENE_AVAILABLE_IN_1_2
 void                    graphene_triangle_get_points            (const graphene_triangle_t *t,
                                                                  graphene_point3d_t        *a,

--- a/include/graphene-triangle.h
+++ b/include/graphene-triangle.h
@@ -97,6 +97,13 @@ GRAPHENE_AVAILABLE_IN_1_2
 bool                    graphene_triangle_get_barycoords        (const graphene_triangle_t *t,
                                                                  const graphene_point3d_t  *p,
                                                                  graphene_vec2_t           *res);
+GRAPHENE_AVAILABLE_IN_1_10
+bool                    graphene_triangle_get_uv                (const graphene_triangle_t *t,
+                                                                 const graphene_point3d_t  *p,
+                                                                 const graphene_vec2_t     *uv_a,
+                                                                 const graphene_vec2_t     *uv_b,
+                                                                 const graphene_vec2_t     *uv_c,
+                                                                 graphene_vec2_t           *res);
 
 GRAPHENE_AVAILABLE_IN_1_2
 bool                    graphene_triangle_contains_point        (const graphene_triangle_t *t,

--- a/meson.build
+++ b/meson.build
@@ -162,24 +162,22 @@ else
   error('No aligned malloc function could be found.')
 endif
 
-# Look for sincosf(), a GNU libc extension
-conf.set('HAVE_SINCOSF',
-  cc.has_function('sincosf',
-    prefix: '#include <math.h>',
-    args: [ '-D_GNU_SOURCE' ],
-    dependencies: mathlib,
-  ),
-  description: 'Define if sincosf() is available',
-)
+math_exts = [
+  'sincosf',
+  'isinff',
+  'isnanf',
+]
 
-conf.set('HAVE_ISINFF',
-  cc.has_function('isinff',
-    prefix: '#include <math.h>',
-    args: [ '-D_GNU_SOURCE' ],
-    dependencies: mathlib,
-  ),
-  description: 'Define is isinff() is available',
-)
+foreach mfunc: math_exts
+  conf.set('HAVE_' + mfunc.underscorify().to_upper(),
+    cc.has_function(mfunc,
+      prefix: '#include <math.h>',
+      args: [ '-D_GNU_SOURCE' ],
+      dependencies: mathlib,
+    ),
+    description: 'Define if @0@ is available'.format(mfunc),
+  )
+endforeach
 
 # Debugging
 debug_flags = []

--- a/src/graphene-matrix.c
+++ b/src/graphene-matrix.c
@@ -2012,11 +2012,8 @@ graphene_matrix_decompose (const graphene_matrix_t *m,
       graphene_vec3_init_from_vec3 (shear, graphene_vec3_zero ());
       graphene_vec4_init_from_vec4 (perspective, graphene_vec4_zero ());
     }
-  else
-    {
-      if (!matrix_decompose_3d (m, scale, shear, rotate, translate, perspective))
-        return false;
-    }
+  else if (!matrix_decompose_3d (m, scale, shear, rotate, translate, perspective))
+    return false;
 
   return true;
 }

--- a/src/graphene-triangle.c
+++ b/src/graphene-triangle.c
@@ -152,6 +152,35 @@ graphene_triangle_init_from_vec3 (graphene_triangle_t   *t,
 }
 
 /**
+ * graphene_triangle_init_from_float:
+ * @t: the #graphene_triangle_t to initialize
+ * @a: (not nullable) (array fixed-size=3): an array of 3 floating point values
+ * @b: (not nullable) (array fixed-size=3): an array of 3 floating point values
+ * @c: (not nullable) (array fixed-size=3): an array of 3 floating point values
+ *
+ * Initializes a #graphene_triangle_t using the three given arrays
+ * of floating point values, each representing the coordinates of
+ * a point in 3D space.
+ *
+ * Returns: (transfer none): the initialized #graphene_triangle_t
+ *
+ * Since: 1.10
+ */
+graphene_triangle_t *
+graphene_triangle_init_from_float (graphene_triangle_t *t,
+                                   const float         *a,
+                                   const float         *b,
+                                   const float         *c)
+{
+  graphene_vec3_t va, vb, vc;
+
+  return graphene_triangle_init_from_vec3 (t,
+                                           graphene_vec3_init_from_float (&va, a),
+                                           graphene_vec3_init_from_float (&vb, b),
+                                           graphene_vec3_init_from_float (&vc, c));
+}
+
+/**
  * graphene_triangle_get_points:
  * @t: a #graphene_triangle_t
  * @a: (out caller-allocates) (optional): return location for the coordinates

--- a/tests/ray.c
+++ b/tests/ray.c
@@ -129,6 +129,44 @@ ray_matrix_transform (void)
 }
 
 static void
+ray_intersect_triangle (void)
+{
+  graphene_vec3_t one3;
+  graphene_vec3_init (&one3, 1, 1, 1);
+
+  graphene_ray_t r;
+
+  graphene_triangle_t t;
+  graphene_triangle_init_from_point3d (&t,
+                                       &GRAPHENE_POINT3D_INIT (1, 1, 0),
+                                       &GRAPHENE_POINT3D_INIT (0, 1, 1),
+                                       &GRAPHENE_POINT3D_INIT (1, 0, 1));
+
+  graphene_ray_init (&r, NULL, graphene_vec3_zero ());
+  mutest_expect ("no intersection if ray's direction is zero",
+                 mutest_int_value (graphene_ray_intersect_triangle (&r, &t, NULL)),
+                 mutest_to_be, GRAPHENE_RAY_INTERSECTION_KIND_NONE,
+                 NULL);
+
+  graphene_ray_init (&r, NULL, &one3);
+  mutest_expect ("intersection with backside faces",
+                 mutest_int_value (graphene_ray_intersect_triangle (&r, &t, NULL)),
+                 mutest_to_be, GRAPHENE_RAY_INTERSECTION_KIND_LEAVE,
+                 NULL);
+
+  float d;
+  graphene_ray_init (&r, NULL, &one3);
+  mutest_expect ("intersection without backside faces",
+                 mutest_int_value (graphene_ray_intersect_triangle (&r, &t, &d)),
+                 mutest_not, mutest_to_be, GRAPHENE_RAY_INTERSECTION_KIND_NONE,
+                 NULL);
+  mutest_expect ("intersection distance to be valid",
+                 mutest_float_value (d),
+                 mutest_to_be_close_to, d - 1 / 3, 0.001,
+                 NULL);
+}
+
+static void
 ray_suite (void)
 {
   mutest_it ("can be initialized", ray_init);
@@ -136,6 +174,7 @@ ray_suite (void)
   mutest_it ("can compute the closest approach of a point from the ray", ray_get_distance_to_point);
   mutest_it ("can compute the closest point to a point on the ray", ray_closest_point_to_point);
   mutest_it ("can be transformed", ray_matrix_transform);
+  mutest_it ("can intersect triangles", ray_intersect_triangle);
 }
 
 MUTEST_MAIN (

--- a/tests/triangle.c
+++ b/tests/triangle.c
@@ -108,6 +108,40 @@ triangle_init_from_vec3 (mutest_spec_t *spec)
 }
 
 static void
+triangle_init_from_float (mutest_spec_t *spec)
+{
+  graphene_vec3_t a, b, c;
+  graphene_vec3_t check_a, check_b, check_c;
+  graphene_triangle_t *t;
+  float v[9] = { 0.f, 1.f, 0.f, 1.f, -1.f, 0.f, -1.f, -1.f, 0.f };
+
+  graphene_vec3_init_from_float (&a, v);
+  graphene_vec3_init_from_float (&b, v + 3);
+  graphene_vec3_init_from_float (&c, v + 6);
+
+  t = graphene_triangle_init_from_float (graphene_triangle_alloc (), v, v + 3, v + 6);
+  graphene_triangle_get_vertices (t, &check_a, &check_b, &check_c);
+  mutest_expect ("triangle.a to match first vector",
+                 mutest_bool_value (graphene_vec3_equal (&check_a, &a)),
+                 mutest_to_be_true,
+                 NULL);
+  mutest_expect ("triangle.b to match second vector",
+                 mutest_bool_value (graphene_vec3_equal (&check_b, &b)),
+                 mutest_to_be_true,
+                 NULL);
+  mutest_expect ("triangle.c to match third vector",
+                 mutest_bool_value (graphene_vec3_equal (&check_c, &c)),
+                 mutest_to_be_true,
+                 NULL);
+  mutest_expect ("a unit triangle to have an area of 2",
+                 mutest_float_value (graphene_triangle_get_area (t)),
+                 mutest_to_be_close_to, 2.0, 0.0001,
+                 NULL);
+
+  graphene_triangle_free (t);
+}
+
+static void
 triangle_contains_point (mutest_spec_t *spec)
 {
   graphene_point3d_t a = GRAPHENE_POINT3D_INIT ( 0.f,  1.f, 0.f);
@@ -398,6 +432,7 @@ triangle_suite (mutest_suite_t *suite)
 {
   mutest_it ("initializes from points", triangle_init_from_point3d);
   mutest_it ("initializes from vectors", triangle_init_from_vec3);
+  mutest_it ("initialized from float arrays", triangle_init_from_float);
   mutest_it ("contains points", triangle_contains_point);
   mutest_it ("defines planes", triangle_plane);
   mutest_it ("defines barycoords", triangle_barycoords);


### PR DESCRIPTION
Gthree has some in tree functionality that really belongs to Graphene.

Proposed changes:

 - add `graphene_triangle_init_from_float()` initializer; this is useful for buffer objects with lots of triangles stored as vectors of floating point values
 - add intersection methods for `graphene_ray_t`; this is used for hit testing objects like spheres, boxes, and triangles
 - add `graphene_triangle_get_uv()`