### PR TITLE
meson: Don't error with MSVC C4819 warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -79,7 +79,7 @@ if cc.get_id() == 'msvc'
     '-we4071',
     '-we4244',
     '-we4150',
-    '-we4819'
+    '/utf-8'
   ]
 else
   test_cflags = [


### PR DESCRIPTION
The compiler warning C4819 (encoding related warning) is a trivial
thing on non-English locale system. Instead of error out,
explicitly specify encoding as "utf-8".