### PR TITLE
Don't use obsolete isinff and isnanf functions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -164,8 +164,6 @@ endif
 
 math_exts = [
   'sincosf',
-  'isinff',
-  'isnanf',
 ]
 
 foreach mfunc: math_exts

--- a/src/graphene-box.c
+++ b/src/graphene-box.c
@@ -427,14 +427,18 @@ graphene_box_get_depth (const graphene_box_t *box)
 static inline bool
 graphene_box_is_empty (const graphene_box_t *box)
 {
-#ifdef HAVE_ISINFF
+#if defined(isinf) && defined(signbit)
   float vmin[3], vmax[3];
 
   graphene_simd4f_dup_3f (box->min.value, vmin);
   graphene_simd4f_dup_3f (box->max.value, vmax);
 
-  return (isinff (vmin[0]) == 1 && isinff (vmin[1]) == 1 && isinff (vmin[2]) == 1) &&
-         (isinff (vmax[0]) == -1 && isinff (vmax[1]) == -1 && isinff (vmax[2]) == -1);
+  return ((isinf (vmin[0]) && !signbit (vmin[0])) &&
+          (isinf (vmin[1]) && !signbit (vmin[1])) &&
+          (isinf (vmin[2]) && !signbit (vmin[2]))) &&
+         ((isinf (vmax[0]) && signbit (vmax[0])) &&
+          (isinf (vmax[1]) && signbit (vmax[1])) &&
+          (isinf (vmax[2]) && signbit (vmax[2])));
 #else
   graphene_simd4f_t neg_inf = graphene_simd4f_init (-INFINITY, -INFINITY, -INFINITY, 0.f);
   graphene_simd4f_t pos_inf = graphene_simd4f_init (INFINITY, INFINITY, INFINITY, 0.f);
@@ -454,14 +458,18 @@ graphene_box_is_empty (const graphene_box_t *box)
 static inline bool
 graphene_box_is_infinity (const graphene_box_t *box)
 {
-#ifdef HAVE_ISINFF
+#if defined(isinf) && defined(signbit)
   float vmin[3], vmax[3];
 
   graphene_simd4f_dup_3f (box->min.value, vmin);
   graphene_simd4f_dup_3f (box->max.value, vmax);
 
-  return (isinff (vmin[0]) == -1 && isinff (vmin[1]) == -1 && isinff (vmin[2]) == -1) &&
-         (isinff (vmax[0]) == 1 && isinff (vmax[1]) == 1 && isinff (vmax[2]) == 1);
+  return ((isinf (vmin[0]) && signbit (vmin[0])) &&
+          (isinf (vmin[1]) && signbit (vmin[1])) &&
+          (isinf (vmin[2]) && signbit (vmin[2]))) &&
+         ((isinf (vmax[0]) && !signbit (vmax[0])) &&
+          (isinf (vmax[1]) && !signbit (vmax[1])) &&
+          (isinf (vmax[2]) && !signbit (vmax[2])));
 #else
   graphene_simd4f_t neg_inf = graphene_simd4f_init (-INFINITY, -INFINITY, -INFINITY, 0.f);
   graphene_simd4f_t pos_inf = graphene_simd4f_init (INFINITY, INFINITY, INFINITY, 0.f);

--- a/src/graphene-ray.c
+++ b/src/graphene-ray.c
@@ -526,10 +526,10 @@ graphene_ray_intersect_box (const graphene_ray_t *r,
   /* These lines also handle the case where tx_min or tx_max is NaN
    * (result of 0 * INFINITY): NaN != NaN
    */
-#ifdef HAVE_ISNANF
-  if (ty_min > tx_min || isnanf (tx_min))
+#ifdef isnan
+  if (ty_min > tx_min || isnan (tx_min))
     tx_min = ty_min;
-  if (ty_max < tx_max || isnanf (tx_max))
+  if (ty_max < tx_max || isnan (tx_max))
     tx_max = ty_max;
 #else
   if (ty_min > tx_min || fpclassify (tx_min) == FP_NAN)
@@ -553,10 +553,10 @@ graphene_ray_intersect_box (const graphene_ray_t *r,
   if ((tx_min > tz_max) || (tz_min > tx_max))
     return GRAPHENE_RAY_INTERSECTION_KIND_NONE;
 
-#ifdef HAVE_ISNANF
-  if (tz_min > tx_min || isnanf (tx_min))
+#ifdef isnan
+  if (tz_min > tx_min || isnan (tx_min))
     tx_min = tz_min;
-  if (tz_max < tx_max || isnanf (tx_max))
+  if (tz_max < tx_max || isnan (tx_max))
     tx_max = tz_max;
 #else
   if (tz_min > tx_min || fpclassify (tx_min) == FP_NAN)

--- a/src/graphene-simd4f.c
+++ b/src/graphene-simd4f.c
@@ -1374,8 +1374,8 @@ approx_equal (float a,
               float b,
               float epsilon)
 {
-#ifdef HAVE_ISINFF
-  if (isinff (a) && isinff (b))
+#ifdef isinf
+  if (isinf (a) && isinf (b))
     return true;
 #else
   if (fpclassify (a) == FP_INFINITE && fpclassify (b) == FP_INFINITE)


### PR DESCRIPTION
GNU libc already marks isinff and isnanf functions as obsolete. They
have been replaced by isinf and isnan macros defined by C99. Since we
already requires C99 in this project, it should be nice if we can
switch to standard macros.

Proposed changes:

 - Drop the use of non-standard and obsolete isinff and isnanf functions.

Benchmark results:

 - None

Test suite changes:

 - None