### PR TITLE
Few fixes for Visual Studio builds

### DIFF
--- a/include/graphene-config.h.meson
+++ b/include/graphene-config.h.meson
@@ -14,8 +14,7 @@ extern "C" {
 #ifndef GRAPHENE_SIMD_BENCHMARK
 
 # if defined(__SSE__) || \
-   (defined(_M_X64) && (_M_X64 > 0)) || \
-   (defined(_MSC_VER) && (_MSC_VER >= 1910))
+   (defined(_M_X64) && (_M_X64 > 0))
 #mesondefine GRAPHENE_HAS_SSE
 # endif
 

--- a/meson.build
+++ b/meson.build
@@ -79,7 +79,7 @@ if cc.get_id() == 'msvc'
     '-we4071',
     '-we4244',
     '-we4150',
-    '/utf-8'
+    '-utf-8'
   ]
 else
   test_cflags = [
@@ -115,6 +115,13 @@ else
 endif
 
 common_cflags = cc.get_supported_arguments(test_cflags)
+
+# MSVC: Let C4819 error out if we do not have the -utf-8 compiler flag
+if cc.get_id() == 'msvc'
+  if not common_cflags.contains('-utf-8')
+    common_cflags += cc.get_supported_arguments('-we4819')
+  endif
+endif
 
 common_ldflags = []
 if host_system == 'linux'

--- a/meson.build
+++ b/meson.build
@@ -253,12 +253,10 @@ if get_option('sse2')
 # if !defined(__amd64__) && !defined(__x86_64__)
 #   error "Need GCC >= 4.9 for SSE2 intrinsics on x86"
 # endif
-#elif defined (_MSC_VER) && (_MSC_VER < 1910)
-# if !defined (_M_X64) && !defined (_M_AMD64)
-#   error "Need MSVC 2017 or later for SSE2 intrinsics on x86"
-# endif
+#elif defined (_MSC_VER) && !defined (_M_X64) && !defined (_M_AMD64)
+# error "SSE2 intrinsics not supported on x86 MSVC builds"
 #endif
-#if defined(__SSE__) || (_M_X64 > 0) || (_MSC_VER >= 1910)
+#if defined(__SSE__) || (_M_X64 > 0)
 # include <mmintrin.h>
 # include <xmmintrin.h>
 # include <emmintrin.h>

--- a/meson.build
+++ b/meson.build
@@ -368,6 +368,10 @@ src_inc = include_directories('src')
 subdir('src')
 
 if get_option('tests')
+  if cc.get_id() == 'msvc' and cc.version().version_compare('<19')
+    warning('Tests, specifically the mutest library, cannot be built for pre-2015 Visual Studio builds.')
+    warning('Use \'meson configure -Dtests=false\' if you are sure you want to proceed.')
+  endif
   subdir('tests')
 endif
 


### PR DESCRIPTION
Hi,

This updates the build for Visual Studio builds, as follows:

*  Support Visual Studio 2013 builds better-re-enable erroring out on C4819 when /utf-8 (a Visual Studio 2015+ feature) is not supported, to avoid mis-compilations, and let people know that it is actually possible to build Graphene as-is with Visual Studio 2013, but at the cost of needing to explicitly disable building and running the tests.

*  Disable SSE2 builds for all 32-bit x86 Visual Studio builds.  This is because although Visual Studio 2017 and 2019 improved on the __vectorcall calling convention (ABI), that needs to be used for 32-bit x86 builds, which is enough for running Graphene itself with the test programs, but this proved to be not enough to run more involved programs, such as GTK master.  Note that x64 Visual Studio builds continue to support SSE2/SSE4.1 as they did before, Visual Studio 2013 included.

With blessings, thank you!