### PR TITLE
tests: installed tests should use TAP

### DIFF
--- a/tests/gen-installed-test.py
+++ b/tests/gen-installed-test.py
@@ -29,7 +29,11 @@ def write_template(filename, data):
         f.write(data)
 
 def build_template(testdir, testname):
-    return "[Test]\nType=session\nExec={}\n".format(os.path.join(testdir, testname))
+    return """[Test]
+Type=session
+Exec={}
+TestEnvironment=MUTEST_OUTPUT=tap;
+""".format(os.path.join(testdir, testname))
 
 argparser = argparse.ArgumentParser(description='Generate installed-test data.')
 argparser.add_argument('--testdir', metavar='dir', required=True, help='Installed test directory')


### PR DESCRIPTION
The GNOME installed tests system expects the test output to be TAP:

"The key Output (if specified) can only take one value at present, which is TAP. This specifies that the test outputs Test Anything Protocol."
(https://wiki.gnome.org/Initiatives/GnomeGoals/InstalledTests)

Export MUTEST_OUTPUT=tap so this is the case.

Fixes #...

Proposed changes:

 - ...

Benchmark results:

 - Before: ...
 - After: ...

Test suite changes:

 - ...
