### PR TITLE
meson: Fix check for builtype arguments

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -188,11 +188,12 @@ endforeach
 
 # Debugging
 debug_flags = []
-buildtype = get_option('buildtype')
-if buildtype == 'release'
-  debug_flags += [ '-DG_DISABLE_ASSERT' ]
-elif buildtype.startswith('debug')
+if get_option('debug')
   debug_flags += [ '-DGRAPHENE_ENABLE_DEBUG' ]
+  message('Enabling various debug infrastructure')
+elif get_option('optimization') in ['2', '3', 's']
+  debug_flags += [ '-DG_DISABLE_ASSERT' ]
+  message('Disabling assertions')
 endif
 
 extra_args = []


### PR DESCRIPTION
`get_option('buildtype')` will return `'custom'` for most combinations
of `-Doptimization` and `-Ddebug`, but those two will always be set
correctly if only `-Dbuildtype` is set. So we should look at those
options directly.

For the two-way mapping between `buildtype` and `optimization` + `debug`, see this table:
https://mesonbuild.com/Builtin-options.html#build-type-options

Same change as glib: https://gitlab.gnome.org/GNOME/glib/merge_requests/1433