### PR TITLE
Euler: Fix matrix orientation in euler matrix (de)composition

### DIFF
--- a/src/graphene-euler.c
+++ b/src/graphene-euler.c
@@ -237,8 +237,10 @@ euler_to_matrix (float                    ai,
 
   float m[16];
 
-/* Our matrices are row major */
-#define M(m, r, c) (m)[((r) << 2) + (c)]
+/* Our matrices are row major, however the code below is based on code
+   that assumes matrixes apply from the left, and we apply on the
+   right, so need to flip row/column. */
+#define M(m, r, c) (m)[((c) << 2) + (r)]
 
   /* We need to construct the matrix from float values instead
    * of SIMD vectors because the access is parametrised on the
@@ -299,8 +301,10 @@ matrix_to_euler (const graphene_matrix_t *matrix,
 
   graphene_matrix_to_float (matrix, m);
 
-/* Our matrices are row major */
-#define M(m, r, c) (m)[((r) << 2) + (c)]
+/* Our matrices are row major, however the code below is based on code
+   that assumes matrixes apply from the left, and we apply on the
+   right, so need to flip row/column. */
+#define M(m, r, c) (m)[((c) << 2) + (r)]
 
   float ax, ay, az;
   if (params->repetition)


### PR DESCRIPTION
The euler_to_matrix and matrix_to_euler code is based on:

https://github.com/matthew-brett/transforms3d/blob/master/transforms3d/euler.py

This is num-py and has the same row-major matrixes like graphene. However
that code is based on column vectors being multiplied with the matrix on
the left:

> This module implements intrinsic and extrinsic axes, with standard conventions
> for axes `i`, `j`, `k`.  We assume that the matrix should be applied on the
> left of the vector, and right-handed coordinate systems.  To get the matrix to
> apply on the right of the vector, you need the transpose of the matrix we
> supply here, by the matrix transpose rule: $(M . V)^T = V^T M^T$.

To do the transpose we just change the matrix indexing macro (M) to swap
the row/column.
