### PR TITLE
ARM NEON: Add support for Visual Studio ARM64 builds

### DIFF
--- a/include/graphene-config.h.meson
+++ b/include/graphene-config.h.meson
@@ -18,7 +18,7 @@ extern "C" {
 #mesondefine GRAPHENE_HAS_SSE
 # endif
 
-# if defined(__ARM_NEON__)
+# if defined(__ARM_NEON__) || defined (_M_ARM64)
 #mesondefine GRAPHENE_HAS_ARM_NEON
 # endif
 

--- a/include/graphene-simd4x4f.h
+++ b/include/graphene-simd4x4f.h
@@ -173,6 +173,8 @@ void    graphene_simd4x4f_transpose_in_place    (graphene_simd4x4f_t *s);
 
 #elif defined(GRAPHENE_USE_ARM_NEON)
 
+# ifdef __GNUC__
+
 #define graphene_simd4x4f_transpose_in_place(s) \
   (__extension__ ({ \
     const graphene_simd4f_union_t sx = { (s)->x }; \
@@ -184,6 +186,24 @@ void    graphene_simd4x4f_transpose_in_place    (graphene_simd4x4f_t *s);
     (s)->z = graphene_simd4f_init (sx.f[2], sy.f[2], sz.f[2], sw.f[2]); \
     (s)->w = graphene_simd4f_init (sx.f[3], sy.f[3], sz.f[3], sw.f[3]); \
   }))
+
+# elif defined (_MSC_VER)
+
+#define graphene_simd4x4f_transpose_in_place(s) _simd4x4f_transpose_in_place(s)
+static inline void
+_simd4x4f_transpose_in_place (graphene_simd4x4f_t *s)
+{
+  const graphene_simd4f_union_t sx = { (s)->x };
+  const graphene_simd4f_union_t sy = { (s)->y };
+  const graphene_simd4f_union_t sz = { (s)->z };
+  const graphene_simd4f_union_t sw = { (s)->w };
+  (s)->x = graphene_simd4f_init (sx.f[0], sy.f[0], sz.f[0], sw.f[0]);
+  (s)->y = graphene_simd4f_init (sx.f[1], sy.f[1], sz.f[1], sw.f[1]);
+  (s)->z = graphene_simd4f_init (sx.f[2], sy.f[2], sz.f[2], sw.f[2]);
+  (s)->w = graphene_simd4f_init (sx.f[3], sy.f[3], sz.f[3], sw.f[3]);
+}
+
+# endif
 
 #elif defined(GRAPHENE_USE_SCALAR)
 

--- a/meson.build
+++ b/meson.build
@@ -329,11 +329,13 @@ endif
 neon_cflags = []
 if get_option('arm_neon')
   neon_prog = '''
-#ifndef __ARM_EABI__
-#error "EABI is required (to be sure that calling conventions are compatible)"
-#endif
-#ifndef __ARM_NEON__
-#error "No ARM NEON instructions available"
+#if !defined (_MSC_VER) || defined (__clang__)
+# ifndef __ARM_EABI__
+#  error "EABI is required (to be sure that calling conventions are compatible)"
+# endif
+# ifndef __ARM_NEON__
+#  error "No ARM NEON instructions available"
+# endif
 #endif
 #include <arm_neon.h>
 int main () {
@@ -349,7 +351,12 @@ int main () {
     float32x4_t c = vreinterpretq_f32_u32 (veorq_u32 (vreinterpretq_u32_f32 (s), __mask)); \
     return 0;
 }'''
-  test_neon_cflags = ['-mfpu=neon']
+
+  test_neon_cflags = []
+
+  if cc.get_id() != 'msvc'
+    test_neon_cflags += ['-mfpu=neon']
+  endif
 
   if host_system == 'android'
     test_neon_cflags += ['-mfloat-abi=softfp']

--- a/src/graphene-ray.c
+++ b/src/graphene-ray.c
@@ -52,7 +52,7 @@
 #include <math.h>
 #include <float.h>
 
-#if defined(_WIN64) && ! defined(isnanf)
+#if defined(_M_X64) && ! defined(isnanf)
 # define isnanf(x) _isnanf(x)
 # define HAVE_ISNANF
 #endif


### PR DESCRIPTION
Hi,

This attempts to add support for building Graphene with ARM NEON intrinsics for Visual Studio ARM64 builds, which is introduced with Visual Studio 2017 15.9.x.  This is done in a way like the previous work on the SSE intrinsics for Visual Studio, as there is no extension available that can alleviate us from using a `static inline` function when calling the ARM NEON intrinsics.

This involves:

*  Skip the checks for the presence of the ARM EABI macros and the ARM NEON macros, since those macros are done in a GCC-specific way and are not present (but it seems that Visual Studio offer the functionality that are demanded/offered by those macros).  The test code for ARM NEON intrinsics do compile as a result.  Check for `_M_ARM64` in graphene-config.h.meson as well when checking to see `GRAPHENE_HAS_ARM_NEON` is activated.

*  Add (Re-word) the intrinsics for Visual Studio ARM64 builds in `graphene-simd4f.h` and `graphene-simd4x4.h`, so that GCCisms do not get in the way.  This comes at the cost of using `static inline` functions where needed, as that would be the best we could do, as when we added the SSE intrinsics for Visual Studio builds.  Also add comments for the SSE intrinsics sections so that this distinction between compiler syntax differences is made clearer.

*  Fix building `graphene-ray.c`, where we define `isnanf()` to `_isnanf()` and activate `HAVE_ISNANF` on 64-bit Windows.  Change this to check for `_M_X64` (the Visual Studio macro defined for x64 builds) instead of `_WIN64`, since `_isnanf()` is provided on x64 builds only.

I was able to cross-compile Graphene for Windows 10 ARM with Visual Studio 2019 with ARM NEON intrinsics enabled, and have also built the code with Visual Studio 2019 on a Windows 10 ARM system and run the tests successfully, and the time taken seemed decent enough.

This does not attempt to cover introspection builds, as no official Python binaries exist for ARM64 Windows, so I was not able to build Graphene at this time with introspection support, but GLib/GObject are activated.

With blessings, thank you!