### PR TITLE
Drop deprecated "python3" module

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -374,7 +374,7 @@ endif
 # Scalar is always available as a fallback
 graphene_simd += [ 'scalar' ]
 
-python3 = import('python3')
+python = import('python')
 gnome = import('gnome')
 
 subdir('include')

--- a/src/meson.build
+++ b/src/meson.build
@@ -97,7 +97,7 @@ graphene_dep_sources = []
 
 # Introspection
 if build_gir
-  python = python3.find_python()
+  python = python.find_installation('python3')
   identfilter_py = join_paths(meson.current_source_dir(), 'identfilter.py')
 
   gir_extra_args = [

--- a/tests/gen-installed-test.py
+++ b/tests/gen-installed-test.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright 2017  Emmanuele Bassi
 #
 # SPDX-License-Identifier: MIT

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -19,8 +19,7 @@ unit_tests = [
   'vec4'
 ]
 
-python = python3.find_python()
-gen_installed_test = join_paths(meson.current_source_dir(), 'gen-installed-test.py')
+gen_installed_test = find_program('gen-installed-test.py')
 
 installed_test_datadir = join_paths(get_option('prefix'), get_option('datadir'), 'installed-tests', graphene_api_path)
 installed_test_bindir = join_paths(get_option('prefix'), get_option('libexecdir'), 'installed-tests', graphene_api_path)
@@ -40,7 +39,6 @@ if mutest_dep.found()
     custom_target(wrapper,
       output: wrapper,
       command: [
-        python,
         gen_installed_test,
         '--testdir=@0@'.format(installed_test_bindir),
         '--testname=@0@'.format(unit),


### PR DESCRIPTION
We depend on a new enough version of Meson, so we can drop the old "python3" module, and use the appropriate "python" module API instead.