### PR TITLE
meson: Change introspection option to yielding feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ using configuration options:
  * `-Darm_neon=false` - will disable the ARM NEON fast paths
  * `-Dgcc_vector=false` - will disable the GCC vector intrinsics
 
-If you don't plan on generating introspection data, use `-Dintrospection=false`
+If you don't plan on generating introspection data, use `-Dintrospection=disabled`
 when configuring Graphene; similarly, if you don't plan on using GObject with
 Graphene, use `-Dgobject_types=false`. Disabling GObject types will also
 automatically disable generating introspection data.

--- a/meson.build
+++ b/meson.build
@@ -234,7 +234,13 @@ endif
 
 # Optional dependency on GObject-Introspection; if GObject is disabled
 # then we don't build introspection data either
-build_gir = build_gobject and get_option('introspection') and get_option('default_library') == 'shared'
+gir = find_program('g-ir-scanner', required : get_option('introspection'))
+build_gir = build_gobject and gir.found()
+# Disable g-i when cross compiling by default because it rarely works unless
+# special care has been taken, in which case the user can enable the option.
+if meson.is_cross_build() and not get_option('introspection').enabled()
+  build_gir = false
+endif
 
 # Check for InitOnce on Windows
 if host_system == 'windows'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,8 +4,9 @@ option('gtk_doc', type: 'boolean',
 option('gobject_types', type: 'boolean',
        value: true,
        description: 'Enable GObject types (depends on GObject)')
-option('introspection', type: 'boolean',
-       value: true,
+option('introspection', type: 'feature',
+       value: 'auto',
+       yield: true,
        description: 'Enable GObject Introspection (depends on GObject)')
 option('gcc_vector', type: 'boolean',
        value: true,


### PR DESCRIPTION
This copies the same logic as in GTK+. A yielding feature option has the
advantage that if introspection is disabled in GTK and graphene is built
as subproject it will inherit the value from GTK main project.