### PR TITLE
Use the appropriate notation for alignment attributes

### DIFF
--- a/include/graphene-macros.h
+++ b/include/graphene-macros.h
@@ -41,10 +41,13 @@
 
 #if defined(__GNUC__)
 # define GRAPHENE_ALIGN16  __attribute__((aligned(16)))
+# define GRAPHENE_ALIGNED_DECL(x,val)   x __attribute__((aligned(val)))
 #elif defined(_MSC_VER)
 # define GRAPHENE_ALIGN16  __declspec(align(16))
+# define GRAPHENE_ALIGNED_DECL(x,val)   __declspec(align(val)) x
 #else
 # define GRAPHENE_ALIGN16
+# define GRAPHENE_ALIGNED_DECL(x,val)   x
 #endif
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1910)

--- a/include/graphene-matrix.h
+++ b/include/graphene-matrix.h
@@ -40,7 +40,7 @@ GRAPHENE_BEGIN_DECLS
 struct _graphene_matrix_t
 {
   /*< private >*/
-  GRAPHENE_ALIGN16 GRAPHENE_PRIVATE_FIELD (graphene_simd4x4f_t, value);
+  GRAPHENE_ALIGNED_DECL (GRAPHENE_PRIVATE_FIELD (graphene_simd4x4f_t, value), 16);
 };
 
 GRAPHENE_AVAILABLE_IN_1_0

--- a/include/graphene-simd4f.h
+++ b/include/graphene-simd4f.h
@@ -324,7 +324,7 @@ typedef union {
 #  else
 #   define graphene_simd4f_dot3(a,b) \
   (__extension__ ({ \
-    GRAPHENE_ALIGN16 const unsigned int __mask_bits[] = { 0xffffffff, 0xffffffff, 0xffffffff, 0 }; \
+    const unsigned int __mask_bits[] GRAPHENE_ALIGN16 = { 0xffffffff, 0xffffffff, 0xffffffff, 0 }; \
     const graphene_simd4f_t __mask = _mm_load_ps ((const float *) __mask_bits); \
     const graphene_simd4f_t __m = _mm_mul_ps ((a), (b)); \
     const graphene_simd4f_t __s0 = _mm_and_ps (__m, __mask); \

--- a/include/graphene-vec2.h
+++ b/include/graphene-vec2.h
@@ -44,7 +44,7 @@ GRAPHENE_BEGIN_DECLS
 struct _graphene_vec2_t
 {
   /*< private >*/
-  GRAPHENE_ALIGN16 GRAPHENE_PRIVATE_FIELD (graphene_simd4f_t, value);
+  GRAPHENE_ALIGNED_DECL (GRAPHENE_PRIVATE_FIELD (graphene_simd4f_t, value), 16);
 };
 
 GRAPHENE_AVAILABLE_IN_1_0

--- a/include/graphene-vec3.h
+++ b/include/graphene-vec3.h
@@ -44,7 +44,7 @@ GRAPHENE_BEGIN_DECLS
 struct _graphene_vec3_t
 {
   /*< private >*/
-  GRAPHENE_ALIGN16 GRAPHENE_PRIVATE_FIELD (graphene_simd4f_t, value);
+  GRAPHENE_ALIGNED_DECL (GRAPHENE_PRIVATE_FIELD (graphene_simd4f_t, value), 16);
 };
 
 GRAPHENE_AVAILABLE_IN_1_0

--- a/include/graphene-vec4.h
+++ b/include/graphene-vec4.h
@@ -42,7 +42,7 @@ GRAPHENE_BEGIN_DECLS
 struct _graphene_vec4_t
 {
   /*< private >*/
-  GRAPHENE_ALIGN16 GRAPHENE_PRIVATE_FIELD (graphene_simd4f_t, value);
+  GRAPHENE_ALIGNED_DECL (GRAPHENE_PRIVATE_FIELD (graphene_simd4f_t, value), 16);
 };
 
 GRAPHENE_AVAILABLE_IN_1_0


### PR DESCRIPTION
Instead of relying on GCC accepting the same notation as MSVC.
