### PR TITLE
graphene-config: Hide SIMD implementation from GObject-Introspection

### DIFF
--- a/include/graphene-config.h.meson
+++ b/include/graphene-config.h.meson
@@ -11,41 +11,41 @@
 extern "C" {
 #endif
 
-#ifndef GRAPHENE_SIMD_BENCHMARK
+#ifndef __GI_SCANNER__
+# ifndef GRAPHENE_SIMD_BENCHMARK
 
-# if defined(__SSE__) || \
+#  if defined(__SSE__) || \
    (defined(_M_X64) && (_M_X64 > 0))
 #mesondefine GRAPHENE_HAS_SSE
 # endif
 
-# if defined(__ARM_NEON__) || defined (_M_ARM64)
+#  if defined(__ARM_NEON__) || defined (_M_ARM64)
 #mesondefine GRAPHENE_HAS_ARM_NEON
-# endif
+#  endif
 
-# if defined(__GNUC__) && (__GNUC__ >= 4 && __GNUC_MINOR__ >= 9) && !defined(__arm__)
+#  if defined(__GNUC__) && (__GNUC__ >= 4 && __GNUC_MINOR__ >= 9) && !defined(__arm__)
 #mesondefine GRAPHENE_HAS_GCC
+#  endif
+
+#  define GRAPHENE_HAS_SCALAR 1
+# endif /* GRAPHENE_SIMD_BENCHMARK */
+
+# if defined(GRAPHENE_HAS_SSE)
+#  define GRAPHENE_USE_SSE
+#  define GRAPHENE_SIMD_S "sse"
+# elif defined(GRAPHENE_HAS_ARM_NEON)
+#  define GRAPHENE_USE_ARM_NEON
+#  define GRAPHENE_SIMD_S "neon"
+# elif defined(GRAPHENE_HAS_GCC)
+#  define GRAPHENE_USE_GCC
+#  define GRAPHENE_SIMD_S "gcc"
+# elif defined(GRAPHENE_HAS_SCALAR)
+#  define GRAPHENE_USE_SCALAR
+#  define GRAPHENE_SIMD_S "scalar"
+# else
+#  error "Unsupported platform."
 # endif
 
-# define GRAPHENE_HAS_SCALAR 1
-#endif /* GRAPHENE_SIMD_BENCHMARK */
-
-#if defined(GRAPHENE_HAS_SSE)
-# define GRAPHENE_USE_SSE
-# define GRAPHENE_SIMD_S "sse"
-#elif defined(GRAPHENE_HAS_ARM_NEON)
-# define GRAPHENE_USE_ARM_NEON
-# define GRAPHENE_SIMD_S "neon"
-#elif defined(GRAPHENE_HAS_GCC)
-# define GRAPHENE_USE_GCC
-# define GRAPHENE_SIMD_S "gcc"
-#elif defined(GRAPHENE_HAS_SCALAR)
-# define GRAPHENE_USE_SCALAR
-# define GRAPHENE_SIMD_S "scalar"
-#else
-# error "Unsupported platform."
-#endif
-
-#ifndef __GI_SCANNER__
 # if defined(GRAPHENE_USE_SSE)
 #  include <xmmintrin.h>
 #  include <emmintrin.h>
@@ -82,6 +82,8 @@ typedef struct {
  * our public API, and introspection cannot use the SIMD API
  * directly anyway.
  */
+# define GRAPHENE_USE_SCALAR
+
 typedef struct {
   /*< private >*/
   float x, y, z, w;

--- a/tests/introspection.py
+++ b/tests/introspection.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 Simon McVittie
+#
+# SPDX-License-Identifier: MIT
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import unittest
+import sys
+
+class TestIntrospection(unittest.TestCase):
+    def setUp(self):
+        try:
+            import gi
+        except ImportError:
+            self.skipTest('gi module not available')
+
+        gi.require_version('Graphene', '1.0')
+
+    def test_basics(self):
+        '''Assert that introspection basically works'''
+        from gi.repository import Graphene
+
+        self.assertIsNotNone(Graphene.Box.empty())
+
+    def test_simd_not_exposed(self):
+        '''Assert that SIMD implementation details are not present'''
+        from gi.repository import Graphene
+
+        for name in (
+            'HAS_ARM_NEON',
+            'HAS_GCC',
+            'HAS_SCALAR',
+            'HAS_SSE',
+            'SIMD_S',
+            'USE_ARM_NEON',
+            'USE_GCC',
+            'USE_SCALAR',
+            'USE_SSE',
+        ):
+            with self.assertRaises(
+                AttributeError,
+                msg='%s should not be defined' % name,
+            ):
+                getattr(Graphene, name)
+
+def main():
+    try:
+        from tap.runner import TAPTestRunner
+    except ImportError:
+        # Minimal TAP implementation
+        print('1..1')
+        program = unittest.main(exit=False)
+        if program.result.wasSuccessful():
+            print('ok 1 - %r' % program.result)
+        else:
+            print('not ok 1 - %r' % program.result)
+    else:
+        runner = TAPTestRunner()
+        runner.set_stream(True)
+        unittest.main(testRunner=runner)
+
+if __name__ == '__main__':
+    main()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -62,3 +62,31 @@ if mutest_dep.found()
     )
   endforeach
 endif
+
+if build_gir and host_system == 'linux' and not meson.is_cross_build()
+  foreach unit: ['introspection.py']
+    wrapper = '@0@.test'.format(unit)
+    custom_target(wrapper,
+      output: wrapper,
+      command: [
+        gen_installed_test,
+        '--testdir=@0@'.format(installed_test_bindir),
+        '--testname=@0@'.format(unit),
+        '--outdir=@OUTDIR@',
+        '--outfile=@0@'.format(wrapper),
+      ],
+      install: get_option('installed_tests'),
+      install_dir: installed_test_datadir,
+    )
+
+    test(unit,
+      python,
+      args: [files(unit)],
+      env: [
+        'GI_TYPELIB_PATH=' + join_paths(meson.current_build_dir(), '..', 'src'),
+        'LD_LIBRARY_PATH=' + join_paths(meson.current_build_dir(), '..', 'src'),
+      ],
+      protocol: 'tap',
+    )
+  endforeach
+endif


### PR DESCRIPTION
Exposing the various #mesondefine'd constants results in the GIR XML
unnecessarily varying between architectures.

Conversely, GObject-Introspection's rather simplistic cpp parser
thinks GRAPHENE_SIMD_S is always defined to "sse", even on
architectures where it should not be.

Introspected code is not going to be able to use SIMD anyway, so this
doesn't seem to have any value.

Resolves: https://github.com/ebassi/graphene/issues/211

---

Not tested yet, but hopefully fixes #211.

Proposed changes:

 - Wrap more of graphene-config.h in `#ifndef __GI_SCANNER__`

Benchmark results:

 - not benchmarked

Test suite changes:

 - Add a smoke-test for GObject-Introspection using PyGI