### PR TITLE
simd4f: Make reciprocal operations 0-safe

### DIFF
--- a/include/graphene-config.h.meson
+++ b/include/graphene-config.h.meson
@@ -23,7 +23,7 @@ extern "C" {
 #mesondefine GRAPHENE_HAS_ARM_NEON
 #  endif
 
-#  if defined(__GNUC__) && (__GNUC__ >= 4 && __GNUC_MINOR__ >= 9) && !defined(__arm__)
+#  if defined(__GNUC__) && (__GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)) && !defined(__arm__)
 #mesondefine GRAPHENE_HAS_GCC
 #  endif
 

--- a/include/graphene-simd4f.h
+++ b/include/graphene-simd4f.h
@@ -897,19 +897,19 @@ typedef int graphene_simd4i_t __attribute__((vector_size (16)));
 
 # define graphene_simd4f_cross3(a,b) \
   (__extension__ ({ \
-    const graphene_simd4f_t __a = (a); \
-    const graphene_simd4f_t __b = (b); \
-    graphene_simd4f_init (__a[1] * __b[2] - __a[2] * __b[1], \
-                          __a[2] * __b[0] - __a[0] * __b[2], \
-                          __a[0] * __b[1] - __a[1] * __b[0], \
+    const graphene_simd4f_t __cross_a = (a); \
+    const graphene_simd4f_t __cross_b = (b); \
+    graphene_simd4f_init (__cross_a[1] * __cross_b[2] - __cross_a[2] * __cross_b[1], \
+                          __cross_a[2] * __cross_b[0] - __cross_a[0] * __cross_b[2], \
+                          __cross_a[0] * __cross_b[1] - __cross_a[1] * __cross_b[0], \
                           0.f); \
   }))
 
 # define graphene_simd4f_dot3(a,b) \
   (__extension__ ({ \
-    const graphene_simd4f_t __a = (a); \
-    const graphene_simd4f_t __b = (b); \
-    const float __res = __a[0] * __b[0] + __a[1] * __b[1] + __a[2] * __b[2]; \
+    const graphene_simd4f_t __dot_a = (a); \
+    const graphene_simd4f_t __dot_b = (b); \
+    const float __res = __dot_a[0] * __dot_b[0] + __dot_a[1] * __dot_b[1] + __dot_a[2] * __dot_b[2]; \
     graphene_simd4f_init (__res, __res, __res, __res); \
   }))
 

--- a/include/graphene-simd4f.h
+++ b/include/graphene-simd4f.h
@@ -856,12 +856,15 @@ typedef int graphene_simd4i_t __attribute__((vector_size (16)));
 
 # define graphene_simd4f_reciprocal(v) \
   (__extension__ ({ \
+    _Pragma ("GCC diagnostic push") \
+    _Pragma ("GCC diagnostic ignored \"-Wfloat-equal\"") \
     (graphene_simd4f_t) { \
       (v)[0] != 0.f ? 1.f / (v)[0] : 0.f, \
       (v)[1] != 0.f ? 1.f / (v)[1] : 0.f, \
       (v)[2] != 0.f ? 1.f / (v)[2] : 0.f, \
       (v)[3] != 0.f ? 1.f / (v)[3] : 0.f, \
     }; \
+    _Pragma ("GCC diagnostic pop") \
   }))
 
 # define graphene_simd4f_sqrt(v) \
@@ -876,12 +879,15 @@ typedef int graphene_simd4i_t __attribute__((vector_size (16)));
 
 # define graphene_simd4f_rsqrt(v) \
   (__extension__ ({ \
+    _Pragma ("GCC diagnostic push") \
+    _Pragma ("GCC diagnostic ignored \"-Wfloat-equal\"") \
     (graphene_simd4f_t) { \
       (v)[0] != 0.f ? 1.f / sqrtf ((v)[0]) : 0.f, \
       (v)[1] != 0.f ? 1.f / sqrtf ((v)[1]) : 0.f, \
       (v)[2] != 0.f ? 1.f / sqrtf ((v)[2]) : 0.f, \
       (v)[3] != 0.f ? 1.f / sqrtf ((v)[3]) : 0.f, \
     }; \
+    _Pragma ("GCC diagnostic pop") \
   }))
 
 # define graphene_simd4f_add(a,b)       (__extension__ ({ (graphene_simd4f_t) ((a) + (b)); }))
@@ -994,49 +1000,64 @@ typedef int graphene_simd4i_t __attribute__((vector_size (16)));
 
 # define graphene_simd4f_cmp_eq(a,b) \
   (__extension__ ({ \
+    _Pragma ("GCC diagnostic push") \
+    _Pragma ("GCC diagnostic ignored \"-Wfloat-equal\"") \
     const graphene_simd4i_t __res = (a) == (b); \
     (bool) (__res[0] != 0 && \
             __res[1] != 0 && \
             __res[2] != 0 && \
             __res[3] != 0); \
+    _Pragma ("GCC diagnostic pop") \
   }))
 
 # define graphene_simd4f_cmp_neq(a,b) (!graphene_simd4f_cmp_eq (a,b))
 
 # define graphene_simd4f_cmp_lt(a,b) \
   (__extension__ ({ \
+    _Pragma ("GCC diagnostic push") \
+    _Pragma ("GCC diagnostic ignored \"-Wfloat-equal\"") \
     const graphene_simd4i_t __res = (a) < (b); \
     (bool) (__res[0] != 0 && \
             __res[1] != 0 && \
             __res[2] != 0 && \
             __res[3] != 0); \
+    _Pragma ("GCC diagnostic pop") \
   }))
 
 # define graphene_simd4f_cmp_le(a,b) \
   (__extension__ ({ \
+    _Pragma ("GCC diagnostic push") \
+    _Pragma ("GCC diagnostic ignored \"-Wfloat-equal\"") \
     const graphene_simd4i_t __res = (a) <= (b); \
     (bool) (__res[0] != 0 && \
             __res[1] != 0 && \
             __res[2] != 0 && \
             __res[3] != 0); \
+    _Pragma ("GCC diagnostic pop") \
   }))
 
 # define graphene_simd4f_cmp_ge(a,b) \
   (__extension__ ({ \
+    _Pragma ("GCC diagnostic push") \
+    _Pragma ("GCC diagnostic ignored \"-Wfloat-equal\"") \
     const graphene_simd4i_t __res = (a) >= (b); \
     (bool) (__res[0] != 0 && \
             __res[1] != 0 && \
             __res[2] != 0 && \
             __res[3] != 0); \
+    _Pragma ("GCC diagnostic pop") \
   }))
 
 # define graphene_simd4f_cmp_gt(a,b) \
   (__extension__ ({ \
+    _Pragma ("GCC diagnostic push") \
+    _Pragma ("GCC diagnostic ignored \"-Wfloat-equal\"") \
     const graphene_simd4i_t __res = (a) > (b); \
     (bool) (__res[0] != 0 && \
             __res[1] != 0 && \
             __res[2] != 0 && \
             __res[3] != 0); \
+    _Pragma ("GCC diagnostic pop") \
   }))
 
 # define graphene_simd4f_neg(s) \

--- a/meson.build
+++ b/meson.build
@@ -260,6 +260,22 @@ int main (void) {
   )
 endif
 
+# Check for IEEE 754 floating-point division compilance
+float_division_prog = '''
+#include <math.h>
+int main() {
+ if (isinf(1.f / 0.f) != 1)
+   return 1;
+ if (isinf(1.f / -0.f) != -1)
+   return 2;
+ return 0;
+}
+'''
+conf.set('HAVE_IEEE_754_FLOAT_DIVISION',
+  cc.run(float_division_prog, name: 'IEEE 754 floating-point division').returncode() == 0,
+  description: 'Define if floating-point division is compliant with IEEE 754',
+)
+
 # Configuration for our installed config header
 graphene_conf = configuration_data()
 

--- a/src/graphene-ray.c
+++ b/src/graphene-ray.c
@@ -467,22 +467,6 @@ graphene_ray_intersects_sphere (const graphene_ray_t    *r,
   return graphene_ray_intersect_sphere (r, s, NULL) != GRAPHENE_RAY_INTERSECTION_KIND_NONE;
 }
 
-static inline float
-nudge_off_axis (float v)
-{
-  if (graphene_approx_val (v, 0.f))
-    {
-      if (v < 0.f)
-        return -2 * FLT_EPSILON;
-      else
-        return 2 * FLT_EPSILON;
-    }
-  else
-    {
-      return v;
-    }
-}
-
 /**
  * graphene_ray_intersect_box:
  * @r: a #graphene_ray_t
@@ -501,18 +485,10 @@ graphene_ray_intersect_box (const graphene_ray_t *r,
                             const graphene_box_t *b,
                             float                *t_out)
 {
-  graphene_vec3_t safe_direction;
   graphene_vec3_t inv_dir;
-  float d[3];
-
-  graphene_vec3_to_float (&r->direction, d);
-  graphene_vec3_init (&safe_direction,
-                      nudge_off_axis (d[0]),
-                      nudge_off_axis (d[1]),
-                      nudge_off_axis (d[2]));
 
   /* FIXME: Needs a graphene_vec3_reciprocal() */
-  inv_dir.value = graphene_simd4f_reciprocal (safe_direction.value);
+  inv_dir.value = graphene_simd4f_reciprocal (r->direction.value);
 
   graphene_vec3_t inv_min;
   graphene_vec3_subtract (&(b->min), &r->origin, &inv_min);

--- a/src/graphene-simd4f.c
+++ b/src/graphene-simd4f.c
@@ -1180,10 +1180,17 @@ graphene_simd4f_t
 (graphene_simd4f_reciprocal) (graphene_simd4f_t v)
 {
   graphene_simd4f_t s = {
+#if defined (HAVE_IEEE_754_FLOAT_DIVISION)
+    1.0f / v.x,
+    1.0f / v.y,
+    1.0f / v.z,
+    1.0f / v.w
+#else
     fabsf (v.x) > FLT_EPSILON ? 1.0f / v.x : copysignf (INFINITY, v.x),
     fabsf (v.y) > FLT_EPSILON ? 1.0f / v.y : copysignf (INFINITY, v.y),
     fabsf (v.z) > FLT_EPSILON ? 1.0f / v.z : copysignf (INFINITY, v.z),
     fabsf (v.w) > FLT_EPSILON ? 1.0f / v.w : copysignf (INFINITY, v.w)
+#endif
   };
   return s;
 }

--- a/src/graphene-simd4f.c
+++ b/src/graphene-simd4f.c
@@ -436,6 +436,8 @@ graphene_simd4f_t
  * @s: a #graphene_simd4f_t
  *
  * Computes the reciprocal of every component of @s.
+ * The reciprocals of positive and negative 0 are defined
+ * as positive and negative infinity, respectively.
  *
  * |[<!-- language="plain" -->
  *   {
@@ -1178,10 +1180,10 @@ graphene_simd4f_t
 (graphene_simd4f_reciprocal) (graphene_simd4f_t v)
 {
   graphene_simd4f_t s = {
-    fabsf (v.x) > FLT_EPSILON ? 1.0f / v.x : 0.f,
-    fabsf (v.y) > FLT_EPSILON ? 1.0f / v.y : 0.f,
-    fabsf (v.z) > FLT_EPSILON ? 1.0f / v.z : 0.f,
-    fabsf (v.w) > FLT_EPSILON ? 1.0f / v.w : 0.f
+    fabsf (v.x) > FLT_EPSILON ? 1.0f / v.x : copysignf (INFINITY, v.x),
+    fabsf (v.y) > FLT_EPSILON ? 1.0f / v.y : copysignf (INFINITY, v.y),
+    fabsf (v.z) > FLT_EPSILON ? 1.0f / v.z : copysignf (INFINITY, v.z),
+    fabsf (v.w) > FLT_EPSILON ? 1.0f / v.w : copysignf (INFINITY, v.w)
   };
   return s;
 }

--- a/tests/simd.c
+++ b/tests/simd.c
@@ -263,6 +263,64 @@ simd_operators_max (void)
 }
 
 static void
+simd_operators_reciprocal (void)
+{
+  graphene_simd4f_t a, b;
+
+  a = graphene_simd4f_init (1.f, -1.f, -8.f, 0.5f);
+
+  b = graphene_simd4f_reciprocal (a);
+  mutest_expect ("reciprocal() to return the reciprocal of the X component",
+                 mutest_float_value (graphene_simd4f_get_x (b)),
+                 mutest_to_be_close_to, 1.f, FLT_EPSILON,
+                 NULL);
+  mutest_expect ("reciprocal() to return the reciprocal of the Y component",
+                 mutest_float_value (graphene_simd4f_get_y (b)),
+                 mutest_to_be_close_to, -1.f, FLT_EPSILON,
+                 NULL);
+  mutest_expect ("reciprocal() to return the reciprocal of the Z component",
+                 mutest_float_value (graphene_simd4f_get_z (b)),
+                 mutest_to_be_close_to, -0.125f, FLT_EPSILON,
+                 NULL);
+  mutest_expect ("reciprocal() to return the reciprocal of the W component",
+                 mutest_float_value (graphene_simd4f_get_w (b)),
+                 mutest_to_be_close_to, 2.f, FLT_EPSILON,
+                 NULL);
+
+  a = graphene_simd4f_init (.1234f, -1234.f, -0.4321f, 4321.f);
+
+  b = graphene_simd4f_reciprocal (a);
+  mutest_expect ("reciprocal() to return the approximate reciprocal of the X component",
+                 mutest_float_value (graphene_simd4f_get_x (b)),
+                 mutest_to_be_close_to, 8.103727714749, 0.000001,
+                 NULL);
+  mutest_expect ("reciprocal() to return the approximate reciprocal of the Y component",
+                 mutest_float_value (graphene_simd4f_get_y (b)),
+                 mutest_to_be_close_to, -0.000810372771, 0.000001,
+                 NULL);
+  mutest_expect ("reciprocal() to return the approximate reciprocal of the Z component",
+                 mutest_float_value (graphene_simd4f_get_z (b)),
+                 mutest_to_be_close_to, -2.31427910206, 0.000001,
+                 NULL);
+  mutest_expect ("reciprocal() to return the approximate reciprocal of the W component",
+                 mutest_float_value (graphene_simd4f_get_w (b)),
+                 mutest_to_be_close_to, 0.00023142791, 0.000001,
+                 NULL);
+
+  a = graphene_simd4f_init (0.f, -0.f, 5.f, -10.f);
+
+  b = graphene_simd4f_reciprocal (a);
+  mutest_expect ("reciprocal() to return positive infinity in the X component",
+                 mutest_float_value (graphene_simd4f_get_x (b)),
+                 mutest_to_be_positive_infinity,
+                 NULL);
+  mutest_expect ("reciprocal() to return negative infinity in the Y component",
+                 mutest_float_value (graphene_simd4f_get_y (b)),
+                 mutest_to_be_negative_infinity,
+                 NULL);
+}
+
+static void
 simd_suite (void)
 {
   mutest_it ("can copy 4 components", simd_dup_4f);
@@ -279,6 +337,8 @@ simd_suite (void)
 
   mutest_it ("can compute the minimum vector and scalar", simd_operators_min);
   mutest_it ("can compute the maximum vector and scalar", simd_operators_max);
+
+  mutest_it ("can compute the reciprocal of vector", simd_operators_reciprocal);
 }
 
 MUTEST_MAIN (


### PR DESCRIPTION
## Description
From the main commit messages: (performance measurements omitted)
```
    simd4f: Make reciprocal operations 0-safe
    
    Introduce a well-defined behavior for the reciprocal calculation of
    positive and negative 0. These would now result in positive and
    negative infinity, respectively.
    
    This behavior follows the definition of the IEEE 754 standard.
    
    In the SSE implementation, _mm_rcp_ps() already returned positive or
    negative infinity when used on a positive or negative 0. However, since
    it is then multiplied by 0, we end up with NaN. NaN is then used in the
    next calculations, which finally result in it being returned.
    
    To avoid ending up with NaN, we use a mask created by _mm_cmpeq_ps()
    and a constant, and along with _mm_andnot_ps() we replace infinity with
    0 in the multiplication. After the following subtraction, we end up
    with 2 multiplied by the positive or negative infinity, which finally
    returns the expected result.
    
    The GCC vectorization and scalar implementations are adjusted to return
    infinity when calculating the reciprocal of 0, with copysign() used to
    set the expected sign of the result.
    
    The ARM NEON implementation doesn't require adjusting as it is already
    0-safe.
    
    This comes at a cost of ~11.9% for the SSE implementation, while the
    performance of the GCC vectorization and scalar implementations
    largely remains the same.
```
```
    ray: Remove nudging workaround
    
    Since the reciprocals of positive and negative 0 are now well-defined,
    this workaround should no longer be needed.
```
## Performance
### Tests
`ray-speed`: 50,000,000 ray intersection tests with a box, each using a unique ray.
`simd-speed`: 100,000,000 vector reciprocal calculations, each using a unique vector.
### Results
The following are measurements made for the entire PR. For measurements made for each individual commit, see the commit message.
```
SSE
  BEFORE
    1/2 graphene / ray-speed  OK             1.27s
    2/2 graphene / simd-speed OK             0.42s
  AFTER
    1/2 graphene / ray-speed  OK             1.12s
    2/2 graphene / simd-speed OK             0.47s

GCC VECTORIZATION
  BEFORE
    1/2 graphene / ray-speed  OK             1.32s
    2/2 graphene / simd-speed OK             1.12s
  AFTER
    1/2 graphene / ray-speed  OK             1.27s
    2/2 graphene / simd-speed OK             1.12s

SCALAR
  BEFORE
    1/2 graphene / ray-speed  OK             2.02s
    2/2 graphene / simd-speed OK             1.62s
  AFTER
    1/2 graphene / ray-speed  OK             1.87s
    2/2 graphene / simd-speed OK             1.32s
```
## Status
Ready. The following items were done:
- [x] Add unit tests.
- [x] Measure performance and optimize where possible.
- [x] Test the SSE implementation and adjust where necessary.
- [x] Test the GCC vectorization implementation and adjust where necessary.
- [x] Test the scalar implementation and adjust where necessary.
- [x] Test the ARM NEON implementation and adjust where necessary.

## Dependencies
The following PRs are included in this PR until merged:
- #219 for the GCC vectorization adjustments