### PR TITLE
build: Fix ARM64 (aarch64) builds on Visual Studio 2017

### DIFF
--- a/include/graphene-config.h.meson
+++ b/include/graphene-config.h.meson
@@ -21,11 +21,6 @@ extern "C" {
 
 #  if defined(__ARM_NEON__) || defined (_M_ARM64) || defined (__aarch64__)
 #mesondefine GRAPHENE_HAS_ARM_NEON
-#   if defined (_MSC_VER) && (_MSC_VER < 1920) && defined (_M_ARM64)
-#    define GRAPHENE_ARM_NEON_HEADER <arm64_neon.h>
-#   else
-#    define GRAPHENE_ARM_NEON_HEADER <arm_neon.h>
-#   endif
 #  endif
 
 #  if defined(__GNUC__) && (__GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)) && !defined(__arm__)
@@ -68,7 +63,11 @@ extern "C" {
 #  endif
 typedef __m128 graphene_simd4f_t;
 # elif defined(GRAPHENE_USE_ARM_NEON)
-#  include GRAPHENE_ARM_NEON_HEADER
+#  if defined (_MSC_VER) && (_MSC_VER < 1920) && defined (_M_ARM64)
+#   include <arm64_neon.h>
+#  else
+#   include <arm_neon.h>
+#  endif
 typedef float32x4_t graphene_simd4f_t;
 # elif defined(GRAPHENE_USE_GCC)
 typedef float graphene_simd4f_t __attribute__((vector_size(16)));

--- a/include/graphene-config.h.meson
+++ b/include/graphene-config.h.meson
@@ -21,6 +21,11 @@ extern "C" {
 
 #  if defined(__ARM_NEON__) || defined (_M_ARM64) || defined (__aarch64__)
 #mesondefine GRAPHENE_HAS_ARM_NEON
+#   if defined (_MSC_VER) && (_MSC_VER < 1920) && defined (_M_ARM64)
+#    define GRAPHENE_ARM_NEON_HEADER <arm64_neon.h>
+#   else
+#    define GRAPHENE_ARM_NEON_HEADER <arm_neon.h>
+#   endif
 #  endif
 
 #  if defined(__GNUC__) && (__GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)) && !defined(__arm__)
@@ -63,7 +68,7 @@ extern "C" {
 #  endif
 typedef __m128 graphene_simd4f_t;
 # elif defined(GRAPHENE_USE_ARM_NEON)
-#  include <arm_neon.h>
+#  include GRAPHENE_ARM_NEON_HEADER
 typedef float32x4_t graphene_simd4f_t;
 # elif defined(GRAPHENE_USE_GCC)
 typedef float graphene_simd4f_t __attribute__((vector_size(16)));

--- a/meson.build
+++ b/meson.build
@@ -362,7 +362,11 @@ if get_option('arm_neon')
 #   endif
 # endif
 #endif
+#if defined (_MSC_VER) && (_MSC_VER < 1920) && defined (_M_ARM64)
+#include <arm64_neon.h>
+#else
 #include <arm_neon.h>
+#endif
 int main () {
     const float32_t __v[4] = { 1, 2, 3, 4 }; \
     const unsigned int __umask[4] = { \

--- a/meson.build
+++ b/meson.build
@@ -363,9 +363,9 @@ if get_option('arm_neon')
 # endif
 #endif
 #if defined (_MSC_VER) && (_MSC_VER < 1920) && defined (_M_ARM64)
-#include <arm64_neon.h>
+# include <arm64_neon.h>
 #else
-#include <arm_neon.h>
+# include <arm_neon.h>
 #endif
 int main () {
     const float32_t __v[4] = { 1, 2, 3, 4 }; \


### PR DESCRIPTION
Hi,

From the commit message:

<i>On Visual Studio 2017, it is unfortunate that it does not allow us to include arm_neon.h directly for ARM64 builds, so we must include arm64_neon.h instead.</i>

<i>Interestingly, Visual Studio 2019 can include arm_neon.h directly for ARM64 builds, which will in turn include arm64_neon.h</i>

<i>Fix the Visual Studio 2017 ARM64 build by:</i>

*  <i>Updating the check program to include arm64_neon.h when building with Visual Studio 2017 for ARM64.</i>

*  <i>Use macros in graphene-config.h.meson so that we include the right header depending on the compiler being used when building for ARM64.</i>

With blessings, thank you!