### PR TITLE
meson: fix gcc vector 64-bit check

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -328,7 +328,7 @@ if get_option('gcc_vector')
 #   error "GCC vector intrinsics are disabled on GCC prior to 4.9"
 # elif defined(__arm__)
 #   error "GCC vector intrinsics are disabled on ARM"
-# elif !defined(__x86_64__)
+# elif (__SIZEOF_POINTER__ < 8)
 #   error "GCC vector intrinsics are disabled on 32bit"
 # endif
 #else


### PR DESCRIPTION
the previous behavior only ever enabled gcc vectors on x86_64

this results in a massive performance improvement in gnome 40 on ppc64le