### PR TITLE
Fix various broken macros when using GCC extension vectors

### DIFF
--- a/include/graphene-simd4f.h
+++ b/include/graphene-simd4f.h
@@ -884,13 +884,14 @@ typedef int graphene_simd4i_t __attribute__((vector_size (16)));
   (__extension__ ({ \
     _Pragma ("GCC diagnostic push") \
     _Pragma ("GCC diagnostic ignored \"-Wfloat-equal\"") \
-    (graphene_simd4f_t) { \
+    const graphene_simd4f_t __val = (graphene_simd4f_t) { \
       (v)[0] != 0.f ? 1.f / sqrtf ((v)[0]) : 0.f, \
       (v)[1] != 0.f ? 1.f / sqrtf ((v)[1]) : 0.f, \
       (v)[2] != 0.f ? 1.f / sqrtf ((v)[2]) : 0.f, \
       (v)[3] != 0.f ? 1.f / sqrtf ((v)[3]) : 0.f, \
     }; \
     _Pragma ("GCC diagnostic pop") \
+    __val; \
   }))
 
 # define graphene_simd4f_add(a,b)       (__extension__ ({ (graphene_simd4f_t) ((a) + (b)); }))
@@ -1006,11 +1007,12 @@ typedef int graphene_simd4i_t __attribute__((vector_size (16)));
     _Pragma ("GCC diagnostic push") \
     _Pragma ("GCC diagnostic ignored \"-Wfloat-equal\"") \
     const graphene_simd4i_t __res = (a) == (b); \
-    (bool) (__res[0] != 0 && \
+    const bool __val = (bool) (__res[0] != 0 && \
             __res[1] != 0 && \
             __res[2] != 0 && \
             __res[3] != 0); \
     _Pragma ("GCC diagnostic pop") \
+    __val; \
   }))
 
 # define graphene_simd4f_cmp_neq(a,b) (!graphene_simd4f_cmp_eq (a,b))
@@ -1020,11 +1022,12 @@ typedef int graphene_simd4i_t __attribute__((vector_size (16)));
     _Pragma ("GCC diagnostic push") \
     _Pragma ("GCC diagnostic ignored \"-Wfloat-equal\"") \
     const graphene_simd4i_t __res = (a) < (b); \
-    (bool) (__res[0] != 0 && \
+    const bool __val = (bool) (__res[0] != 0 && \
             __res[1] != 0 && \
             __res[2] != 0 && \
             __res[3] != 0); \
     _Pragma ("GCC diagnostic pop") \
+    __val; \
   }))
 
 # define graphene_simd4f_cmp_le(a,b) \
@@ -1032,11 +1035,12 @@ typedef int graphene_simd4i_t __attribute__((vector_size (16)));
     _Pragma ("GCC diagnostic push") \
     _Pragma ("GCC diagnostic ignored \"-Wfloat-equal\"") \
     const graphene_simd4i_t __res = (a) <= (b); \
-    (bool) (__res[0] != 0 && \
+    const bool __val = (bool) (__res[0] != 0 && \
             __res[1] != 0 && \
             __res[2] != 0 && \
             __res[3] != 0); \
     _Pragma ("GCC diagnostic pop") \
+    __val; \
   }))
 
 # define graphene_simd4f_cmp_ge(a,b) \
@@ -1044,11 +1048,12 @@ typedef int graphene_simd4i_t __attribute__((vector_size (16)));
     _Pragma ("GCC diagnostic push") \
     _Pragma ("GCC diagnostic ignored \"-Wfloat-equal\"") \
     const graphene_simd4i_t __res = (a) >= (b); \
-    (bool) (__res[0] != 0 && \
+    const bool __val = (bool) (__res[0] != 0 && \
             __res[1] != 0 && \
             __res[2] != 0 && \
             __res[3] != 0); \
     _Pragma ("GCC diagnostic pop") \
+    __val; \
   }))
 
 # define graphene_simd4f_cmp_gt(a,b) \
@@ -1056,11 +1061,12 @@ typedef int graphene_simd4i_t __attribute__((vector_size (16)));
     _Pragma ("GCC diagnostic push") \
     _Pragma ("GCC diagnostic ignored \"-Wfloat-equal\"") \
     const graphene_simd4i_t __res = (a) > (b); \
-    (bool) (__res[0] != 0 && \
+    const bool __val = (bool) (__res[0] != 0 && \
             __res[1] != 0 && \
             __res[2] != 0 && \
             __res[3] != 0); \
     _Pragma ("GCC diagnostic pop") \
+    __val; \
   }))
 
 # define graphene_simd4f_neg(s) \


### PR DESCRIPTION
Commit 8e5c25109898fa4894df810a546b26c387eaae93 introduced some pragmas, however those unintentionally change the types of the macros, as the diagnostic pop pragma becomes the last statement and the type of the expression becomes void.