### PR TITLE
docs: Update link to the matrix deconstruction gem

### DIFF
--- a/src/graphene-matrix.c
+++ b/src/graphene-matrix.c
@@ -2053,7 +2053,7 @@ matrix_decompose_3d (const graphene_matrix_t *m,
  * [CSS3 Transforms specification](http://dev.w3.org/csswg/css-transforms/);
  * specifically, the decomposition code is based on the equivalent code
  * published in "Graphics Gems II", edited by Jim Arvo, and
- * [available online](http://tog.acm.org/resources/GraphicsGems/gemsii/unmatrix.c).
+ * [available online](http://web.archive.org/web/20150512160205/http://tog.acm.org/resources/GraphicsGems/gemsii/unmatrix.c).
  *
  * Returns: `true` if the matrix could be decomposed
  */


### PR DESCRIPTION
The URL now redirects to a random ACM location. Let's use the last
snapshot on the Interner Wayback Machine.

Fixes: #235