### PR TITLE
meson: don't install introspection file with installed_tests=false

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -67,7 +67,9 @@ src_build_path = meson.current_build_dir() / '../src'
 
 if build_gir and host_system == 'linux' and not meson.is_cross_build()
   foreach unit: ['introspection.py']
-    install_data(unit, install_dir: installed_test_bindir)
+    if get_option('installed_tests')
+      install_data(unit, install_dir: installed_test_bindir)
+    endif
 
     wrapper = '@0@.test'.format(unit)
     custom_target(wrapper,


### PR DESCRIPTION
Fixes #247