### PR TITLE
Fix and improve building with clang-cl

### DIFF
--- a/include/graphene-macros.h
+++ b/include/graphene-macros.h
@@ -85,7 +85,7 @@ typedef int bool;
 # include <stdbool.h>
 #endif
 
-#if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1)
+#if defined (__GNUC__) && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))
 #define _GRAPHENE_DEPRECATED __attribute__((__deprecated__))
 #elif defined(_MSC_VER) && (_MSC_VER >= 1300)
 #define _GRAPHENE_DEPRECATED __declspec(deprecated)
@@ -93,7 +93,7 @@ typedef int bool;
 #define _GRAPHENE_DEPRECATED
 #endif
 
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
+#if defined (__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5))
 #define _GRAPHENE_DEPRECATED_FOR(f) __attribute__((__deprecated__("Use '" #f "' instead")))
 #elif defined(_MSC_FULL_VER) && (_MSC_FULL_VER > 140050320)
 #define _GRAPHENE_DEPRECATED_FOR(f) __declspec(deprecated("is deprecated. Use '" #f "' instead"))
@@ -101,7 +101,7 @@ typedef int bool;
 #define _GRAPHENE_DEPRECATED_FOR(f) _GRAPHENE_DEPRECATED
 #endif
 
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
+#if defined (__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5))
 #define _GRAPHENE_UNAVAILABLE(maj,min) __attribute__((deprecated("Not available before " #maj "." #min)))
 #elif defined(_MSC_FULL_VER) && (_MSC_FULL_VER > 140050320)
 #define _GRAPHENE_UNAVAILABLE(maj,min) __declspec(deprecated("is not available before " #maj "." #min))

--- a/include/graphene-simd4f.h
+++ b/include/graphene-simd4f.h
@@ -185,7 +185,7 @@ typedef union {
 } graphene_simd4f_union_t;
 
 /* On GCC, we use __extension__ macros to avoid a static inline */
-# if defined(__GNUC__)
+#if defined (__GNUC__) || defined (__clang__)
 
 /* Use GCC statement __extension__ to inline all these functions */
 
@@ -773,11 +773,11 @@ _simd4f_neg (const graphene_simd4f_t s)
 
 #else /* SSE intrinsics-not GCC or Visual Studio */
 
-#  error "Need GCC-compatible or Visual Studio compiler for SSE extensions."
+#  error "Need GCC/clang-compatible or Visual Studio compiler for SSE extensions."
 
 /* Use static inline to inline all these functions */
 
-# endif /* !__GNUC__ && !_MSC_VER */
+# endif /* !__GNUC__ && !__clang__ && !_MSC_VER */
 
 #elif !defined(__GI_SCANNER__) && defined(GRAPHENE_USE_INTRINSICS)
 
@@ -1089,7 +1089,7 @@ typedef union {
 /* NEON has optimised 2-lanes vectors we can use */
 typedef float32x2_t graphene_simd2f_t;
 
-#ifdef __GNUC__
+#if defined (__GNUC__) || defined (__clang__)
 # define graphene_simd4f_init(x,y,z,w) \
   (__extension__ ({ \
     const float32_t __v[4] = { (x), (y), (z), (w) }; \
@@ -1719,11 +1719,11 @@ _simd4f_neg (const graphene_simd4f_t s)
 
 #else /* ARM NEON intrinsics-not GCC or Visual Studio */
 
-#  error "Need GCC-compatible or Visual Studio compiler for ARM NEON extensions."
+#  error "Need GCC/clang-compatible or Visual Studio compiler for ARM NEON extensions."
 
 /* Use static inline to inline all these functions */
 
-# endif /* !__GNUC__ && !_MSC_VER */
+# endif /* !__GNUC__ && !__clang__ && !_MSC_VER */
 
 /* macros that are not compiler-dependent */
 # define graphene_simd4f_get_x(s)       graphene_simd4f_get (s, 0)

--- a/include/graphene-simd4x4f.h
+++ b/include/graphene-simd4x4f.h
@@ -147,7 +147,7 @@ void    graphene_simd4x4f_transpose_in_place    (graphene_simd4x4f_t *s);
 
 #if defined(GRAPHENE_USE_SSE)
 
-#ifdef __GNUC__
+#if defined (__GNUC__) || defined (__clang__)
 #define graphene_simd4x4f_transpose_in_place(s) \
   (__extension__ ({ \
     _MM_TRANSPOSE4_PS ((s)->x, (s)->y, (s)->z, (s)->w); \
@@ -173,7 +173,7 @@ void    graphene_simd4x4f_transpose_in_place    (graphene_simd4x4f_t *s);
 
 #elif defined(GRAPHENE_USE_ARM_NEON)
 
-# ifdef __GNUC__
+#if defined (__GNUC__) || defined (__clang__)
 
 #define graphene_simd4x4f_transpose_in_place(s) \
   (__extension__ ({ \

--- a/meson.build
+++ b/meson.build
@@ -112,7 +112,10 @@ else
     '-Werror=write-strings',
     '-Werror=undef',
   ]
-  if cc.get_id() != 'clang-cl'
+  if cc.get_id() == 'clang-cl'
+    # We don't want the CRT deprecation warnings from the Visual Studio headers
+    test_cflags += ['-D_CRT_SECURE_NO_WARNINGS', '-D_CRT_NONSTDC_NO_WARNINGS']
+  else
     # This returns a false positive on clang-cl
     test_cflags += '-Wlogical-op'
   endif

--- a/meson.build
+++ b/meson.build
@@ -93,7 +93,6 @@ else
     '-Wunused',
     '-Wmissing-noreturn',
     '-Wmissing-format-attribute',
-    '-Wlogical-op',
     '-Wcast-align',
     '-Wno-unused-local-typedefs',
     '-Werror=float-conversion',
@@ -113,6 +112,10 @@ else
     '-Werror=write-strings',
     '-Werror=undef',
   ]
+  if cc.get_id() != 'clang-cl'
+    # This returns a false positive on clang-cl
+    test_cflags += '-Wlogical-op'
+  endif
 endif
 
 common_cflags = cc.get_supported_arguments(test_cflags)
@@ -203,7 +206,7 @@ if get_option('default_library') != 'static'
   if host_system == 'windows'
     conf.set('DLL_EXPORT', true)
     conf.set('_GRAPHENE_PUBLIC', '__declspec(dllexport) extern')
-    if cc.get_id() != 'msvc'
+    if cc.get_argument_syntax() != 'msvc'
       extra_args += ['-fvisibility=hidden']
     endif
   else
@@ -312,10 +315,14 @@ int main () {
     c = _mm_xor_si128 (a, b);
     return 0;
 }'''
+  test_sse2_cflags = []
   if cc.get_id() != 'msvc'
     test_sse2_cflags = ['-mfpmath=sse', '-msse', '-msse2']
-  else
-    test_sse2_cflags = []
+    if cc.get_id() == 'clang-cl'
+      # clang-cl uses the Visual Studio headers, so we always get SSE 4.1, and it is required
+      test_sse2_cflags += ['-msse4.1']
+    endif
+    test_sse2_cflags = cc.get_supported_arguments(test_sse2_cflags)
   endif
 
   if cc.compiles(sse_prog, args: test_sse2_cflags, name: 'SSE intrinsics')


### PR DESCRIPTION
Hi,

This attempts to fix building with `clang-cl` (the clang compiler that attempts to be MSVC compatible), by:

*  Fixing `graphene-macros.h` by checking for the existance of `__GNUC__` before trying to check its value, since `clang-cl` defines `_MSC_VER` but not `__GNUC__`, unlike clang on *NIX.
*  Improve detection of compiler flags used for `clang-cl`, which follows more the ones used on GCC than Visual Studio, and filter out those that aren't supported.  Also, force `-msse4.1` since that is required for bulding the SSE 4.1 code on `clang-cl`.
* Disable the deprecation warnings that result form the Visual Studio headers, which `clang-cl` utilizes.
* For the SSE/ARM NEON SIMD implementation, make `clang-cl` follow the GCC codepath, since `__extension__` is supported there as well.

With blessings, thank you!