### PR TITLE
meson: Override dependencies to improve usage as a subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -217,13 +217,11 @@ build_gobject = false
 gobject_req_version = '>= 2.30.0'
 if get_option('gobject_types')
   graphene_gobject_api_path = '@0@-gobject-@1@'.format(meson.project_name(), graphene_api_version)
-  # fallback allows us to pick up GObject in case we're a subproject of another
-  # project that uses GObject and where GObject comes from a GLib subproject
-  # (e.g. when building GStreamer or GTK on Windows).
+  # Automatic fallback to a subproject of glib is possible if you install
+  # glib.wrap: meson wrap install glib
   gobject = dependency('gobject-2.0',
     version: gobject_req_version,
     required: false,
-    fallback: ['glib', 'libgobject_dep']
   )
   build_gobject = gobject.found()
   if build_gobject

--- a/src/meson.build
+++ b/src/meson.build
@@ -131,6 +131,10 @@ graphene_dep = declare_dependency(
   include_directories: [ graphene_inc ],
   dependencies: [ mathlib, threadlib ] + platform_deps,
 )
+meson.override_dependency('graphene-1.0', graphene_dep)
+if build_gobject
+  meson.override_dependency('graphene-gobject-1.0', graphene_dep)
+endif
 
 # In case of subproject usage expose a separate variable for graphene-gobject
 # support, so the superproject and sibling subprojects can check for this


### PR DESCRIPTION
With this change, graphene can be consumed as a subproject without
making any changes to the build files of a project. All you need to do
is provide a wrap file with a `[provide]` section:

https://mesonbuild.com/Wrap-dependency-system-manual.html#provide-section

This is also necessary because otherwise projects need to hard-code
the subproject name, which might be `graphene` when using `wrap-git` or
`graphene-1.10.8` when using `wrap-file` (to build from a release
tarball). This can cause conflicts between different subprojects that
consume graphene differently.

Other projects like glib, cairo, pango, etc already do this.

Also, stop using fallback: kwarg for deps that don't need it.