### PR TITLE
Add squared distance operator for 2D points

### DIFF
--- a/doc/graphene-sections.txt
+++ b/doc/graphene-sections.txt
@@ -218,6 +218,7 @@ graphene_point_init_from_point
 graphene_point_init_from_vec2
 graphene_point_equal
 graphene_point_distance
+graphene_point_distance_squared
 graphene_point_near
 graphene_point_interpolate
 graphene_point_to_vec2

--- a/include/graphene-point.h
+++ b/include/graphene-point.h
@@ -98,6 +98,10 @@ float                           graphene_point_distance         (const graphene_
                                                                  float                  *d_x,
                                                                  float                  *d_y);
 
+GRAPHENE_AVAILABLE_IN_1_12
+float                           graphene_point_distance_squared (const graphene_point_t *a,
+                                                                 const graphene_point_t *b);
+
 GRAPHENE_AVAILABLE_IN_1_0
 bool                            graphene_point_near             (const graphene_point_t *a,
                                                                  const graphene_point_t *b,

--- a/src/graphene-point.c
+++ b/src/graphene-point.c
@@ -229,6 +229,31 @@ graphene_point_distance (const graphene_point_t *a,
 }
 
 /**
+ * graphene_point_distance_squared:
+ * @a: a #graphene_point_t
+ * @b: a #graphene_point_t
+ *
+ * Computes the squared distance between @a and @b.
+ *
+ * Returns: the distance between the two points, squared
+ *
+ * Since: 1.12
+ */
+float
+graphene_point_distance_squared (const graphene_point_t *a,
+                                 const graphene_point_t *b)
+{
+  if (a == b)
+    return 0.f;
+
+  graphene_simd4f_t v_a = graphene_simd4f_init (a->x, a->y, 0.f, 0.f);
+  graphene_simd4f_t v_b = graphene_simd4f_init (b->x, b->y, 0.f, 0.f);
+  graphene_simd4f_t v_res = graphene_simd4f_sub (v_a, v_b);
+
+  return graphene_simd4f_get_x (graphene_simd4f_dot2 (v_res, v_res));
+}
+
+/**
  * graphene_point_near:
  * @a: a #graphene_point_t
  * @b: a #graphene_point_t

--- a/tests/point.c
+++ b/tests/point.c
@@ -152,6 +152,12 @@ point_distance (mutest_spec_t *spec)
                  mutest_float_value (y_d),
                  mutest_to_be_close_to, 1.0, 0.00001,
                  NULL);
+
+  d = graphene_point_distance_squared (&p, &q);
+  mutest_expect ("the squared distance between (0, 0) and (1, 1) to be 2",
+                 mutest_float_value (d),
+                 mutest_to_be_close_to, 2.f, 0.0001,
+                 NULL);
 }
 
 static void


### PR DESCRIPTION
A convenience function that computes the squared distance between two points, and avoids the per-axis components of distance().
