### PR TITLE
build: Allow host builds when cross-compiling

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -270,7 +270,7 @@ int main() {
  return 0;
 }
 '''
-if meson.is_cross_build()
+if not meson.can_run_host_binaries()
   ieee754_float_div = meson.get_external_property('ieee754_float_div', cc.get_id() in ['gcc', 'clang'])
   message('Cross-building, assuming IEEE 754 division:', ieee754_float_div)
 else


### PR DESCRIPTION
Environments that set up execution wrappers when cross-compiling should be allowed to run code. We only fall back on external properties if we really can't run any native code on the host machine.