### PR TITLE
docs: Update the URL to directly link to the documentation

### DIFF
--- a/doc/graphene-docs.xml
+++ b/doc/graphene-docs.xml
@@ -11,7 +11,7 @@
       <para>This document is the API reference for the Graphene library.</para>
       <para>
         The latest version of Graphene, as well as the latest version of
-        this API reference, is <ulink role="online-location" url="http://ebassi.github.io/graphene">available online</ulink>.
+        this API reference, is <ulink role="online-location" url="http://ebassi.github.io/graphene/docs">available online</ulink>.
       </para>
     </releaseinfo>
   </bookinfo>


### PR DESCRIPTION
This link get directly inserted into the devhelp2 file and we need to have it actually be the canonical documentation instead of the website itself.